### PR TITLE
Create analyzer to prefer Array.Empty<T>() over new T[0].

### DIFF
--- a/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -22,6 +22,7 @@ namespace WTG.Analyzers.Test
 	[TestFixture(TypeArgs = new[] { typeof(LinqAnalyzer), typeof(LinqCodeFixProvider) })]
 	[TestFixture(TypeArgs = new[] { typeof(DeconstructionAnalyzer), typeof(DeconstructionCodeFixProvider) })]
 	[TestFixture(TypeArgs = new[] { typeof(FlagsAnalyzer), typeof(FlagsCodeFixProvider) })]
+	[TestFixture(TypeArgs = new[] { typeof(ArrayAnalyzer), typeof(ArrayCodeFixProvider) })]
 	class AnalyzerAndCodeFixTest<TAnalyzer, TCodeFix>
 		where TAnalyzer : DiagnosticAnalyzer, new()
 		where TCodeFix : CodeFixProvider, new()

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Diagnostics.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,11-27)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,11-27)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (9,11-26)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (10,12-29)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (15,11-22)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Result.cs
@@ -1,0 +1,17 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = Array.Empty<object[,]>();
+		var s = Array.Empty<string[,]>();
+		var i = Array.Empty<int[,][]>();
+		var ni = Array.Empty<int?[,][,]>();
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = Array.Empty<T[,]>();
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArraysOfMultiDimensionalArrayCreation/Source.cs
@@ -1,0 +1,17 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[0][,];
+		var s = new string[0][,];
+		var i = new int[0][,][];
+		var ni = new int?[0][,][,];
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[0][,];
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationInAttribute/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationInAttribute/Source.cs
@@ -1,0 +1,13 @@
+using System;
+
+[AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+public class ArrayAttribute : Attribute
+{
+	public ArrayAttribute(object[] unused) { }
+}
+
+[Array(new object[0])]
+[ArrayAttribute(new object[0])]
+public class Foo
+{
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Diagnostics.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (9,11-21)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (10,12-23)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (15,11-19)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Result.cs
@@ -1,0 +1,21 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = System.Array.Empty<object>();
+		var s = System.Array.Empty<string>();
+		var i = System.Array.Empty<int>();
+		var ni = System.Array.Empty<int?>();
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = System.Array.Empty<T>();
+	}
+}
+
+public class Array
+{
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithAmbiguities/Source.cs
@@ -1,0 +1,21 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[0];
+		var s = new string[0];
+		var i = new int[0];
+		var ni = new int?[0];
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[0];
+	}
+}
+
+public class Array
+{
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Diagnostics.xml
@@ -15,4 +15,7 @@
 	<diagnostic>
 		<location>Test0.cs: (15,11-19)</location>
 	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (21,4)-(24,8)</location>
+	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Diagnostics.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (9,11-21)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (10,12-23)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (15,11-19)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Result.cs
@@ -1,0 +1,17 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = Array.Empty<object>();
+		var s = Array.Empty<string>();
+		var i = Array.Empty<int>();
+		var ni = Array.Empty<int?>();
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = Array.Empty<T>();
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Result.cs
@@ -14,4 +14,11 @@ public static class Foo
 	{
 		var t = Array.Empty<T>();
 	}
+
+	public static void WithFunkyWhitespace()
+	{
+		var t =
+			Array.Empty<object>()
+		;
+	}
 }

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Source.cs
@@ -14,4 +14,14 @@ public static class Foo
 	{
 		var t = new T[0];
 	}
+
+	public static void WithFunkyWhitespace()
+	{
+		var t =
+			new
+				object[
+					0
+						]
+		;
+	}
 }

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithTopLevelUsing/Source.cs
@@ -1,0 +1,17 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[0];
+		var s = new string[0];
+		var i = new int[0];
+		var ni = new int?[0];
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[0];
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Diagnostics.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (5,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (6,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (7,11-21)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,12-23)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (13,11-19)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Diagnostics.xml
@@ -15,4 +15,7 @@
 	<diagnostic>
 		<location>Test0.cs: (13,11-19)</location>
 	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (19,4)-(22,8)</location>
+	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Result.cs
@@ -12,4 +12,11 @@ public static class Foo
 	{
 		var t = System.Array.Empty<T>();
 	}
+
+	public static void WithFunkyWhitespace()
+	{
+		var t =
+			System.Array.Empty<object>()
+		;
+	}
 }

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Result.cs
@@ -1,0 +1,15 @@
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = System.Array.Empty<object>();
+		var s = System.Array.Empty<string>();
+		var i = System.Array.Empty<int>();
+		var ni = System.Array.Empty<int?>();
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = System.Array.Empty<T>();
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Source.cs
@@ -1,0 +1,15 @@
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[0];
+		var s = new string[0];
+		var i = new int[0];
+		var ni = new int?[0];
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[0];
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/EmptyArrayCreationWithoutUsing/Source.cs
@@ -12,4 +12,14 @@ public static class Foo
 	{
 		var t = new T[0];
 	}
+
+	public static void WithFunkyWhitespace()
+	{
+		var t =
+			new
+				object[
+					0
+						]
+		;
+	}
 }

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/IncompleteCode/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/IncompleteCode/Diagnostics.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<suppressId>CS0246</suppressId>
+	<suppressId>CS0443</suppressId>
+	<suppressId>CS1003</suppressId>
+	<suppressId>CS1526</suppressId>
+	<suppressId>CS1586</suppressId>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/IncompleteCode/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/IncompleteCode/Source.cs
@@ -1,0 +1,32 @@
+public static class Foo
+{
+	public static void F1()
+	{
+		var array = new int;
+	}
+
+	public static void F2()
+	{
+		var array = new int[];
+	}
+
+	public static void F3()
+	{
+		var array = new int[;
+	}
+
+	public static void F4()
+	{
+		var array = new int[0;
+	}
+
+	public static void F5()
+	{
+		var array = new int0];
+	}
+
+	public static void F6()
+	{
+		var array = new int];
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Diagnostics.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,11-31)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,11-29)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (9,11-26)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (10,12-28)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (18,11-24)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (23,33-45)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (24,33-47)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (25,33-46)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (26,33-46)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (27,33-46)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (28,33-47)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (29,33-47)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (30,33-48)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (31,33-48)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (32,33-61)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (33,33-52)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (34,33-53)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (35,33-51)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (36,33-52)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (37,33-46)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (38,33-46)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (39,33-46)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Result.cs
@@ -1,0 +1,43 @@
+using System;
+
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = Array.Empty<object[][]>();
+		var s = Array.Empty<string[]>();
+		var i = Array.Empty<int[]>();
+		var ni = Array.Empty<int?[]>();
+
+		var i2 = new int[][] { new int[6] };
+		var i3 = new int[][] { new int[] { 9 } };
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = Array.Empty<T[]>();
+	}
+
+#pragma warning disable CS0078
+
+	public static int[][] M00() => Array.Empty<int[]>();
+	public static int[][] M01() => Array.Empty<int[]>();
+	public static int[][] M02() => Array.Empty<int[]>();
+	public static int[][] M03() => Array.Empty<int[]>();
+	public static int[][] M04() => Array.Empty<int[]>();
+	public static int[][] M05() => Array.Empty<int[]>();
+	public static int[][] M06() => Array.Empty<int[]>();
+	public static int[][] M07() => Array.Empty<int[]>();
+	public static int[][] M08() => Array.Empty<int[]>();
+	public static int[][] M09() => Array.Empty<int[]>();
+	public static int[][] M10() => Array.Empty<int[]>();
+	public static int[][] M11() => Array.Empty<int[]>();
+	public static int[][] M12() => Array.Empty<int[]>();
+	public static int[][] M13() => Array.Empty<int[]>();
+	public static int[][] M14() => Array.Empty<int[]>();
+	public static int[][] M15() => Array.Empty<int[]>();
+	public static int[][] M16() => Array.Empty<int[]>();
+	public static int[][] E() => Array.Empty<int[]>();
+
+#pragma warning restore CS0078
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Source.cs
@@ -1,15 +1,43 @@
+using System;
+
 public static class Foo
 {
 	public static void ArrayCreator()
 	{
-		var o = new object[][] { };
+		var o = new object[][][] { };
 		var s = new string[][] { };
 		var i = new int[][] { };
 		var ni = new int?[][] { };
+
+		var i2 = new int[][] { new int[6] };
+		var i3 = new int[][] { new int[] { 9 } };
 	}
 
 	public static void GenericArrayCreator<T>()
 	{
 		var t = new T[][] { };
 	}
+
+#pragma warning disable CS0078
+
+	public static int[][] M00() => new int[0][];
+	public static int[][] M01() => new int[0x0][];
+	public static int[][] M02() => new int[0u][];
+	public static int[][] M03() => new int[0l][];
+	public static int[][] M04() => new int[0L][];
+	public static int[][] M05() => new int[0lu][];
+	public static int[][] M06() => new int[0LU][];
+	public static int[][] M07() => new int['\0'][];
+	public static int[][] M08() => new int[][] { };
+	public static int[][] M09() => new int[0b0000___0000_000][];
+	public static int[][] M10() => new int[(short)0][];
+	public static int[][] M11() => new int[(ushort)0][];
+	public static int[][] M12() => new int[(byte)0][];
+	public static int[][] M13() => new int[(sbyte)0][];
+	public static int[][] M14() => new int[00][];
+	public static int[][] M15() => new int[-0][];
+	public static int[][] M16() => new int[+0][];
+	public static int[][] E() => Array.Empty<int[]>();
+
+#pragma warning restore CS0078
 }

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/JaggedArrayCreation/Source.cs
@@ -1,0 +1,15 @@
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[][] { };
+		var s = new string[][] { };
+		var i = new int[][] { };
+		var ni = new int?[][] { };
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[][] { };
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/MultiDimenstionalArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/MultiDimenstionalArrayCreation/Source.cs
@@ -1,0 +1,15 @@
+public static class Foo
+{
+	public static void ArrayCreator()
+	{
+		var o = new object[0, 0];
+		var s = new string[0,0];
+		var i = new int[1,2];
+		var ni = new int?[3, 2];
+	}
+
+	public static void GenericArrayCreator<T>()
+	{
+		var t = new T[0, 0];
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/SizedArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/SizedArrayCreation/Source.cs
@@ -1,0 +1,35 @@
+public static class Foo
+{
+	public static void StaticArrayCreator<T>()
+	{
+		var o = new object[1];
+		var s = new string[2];
+		var i = new int[] { 8 };
+		var ni = new int?[] { 6 };
+
+		var t = new T[4];
+	}
+
+	public static void DynamicArrayCreator<T>(int size = 0)
+	{
+		int GetSize() => 0;
+
+		const int Size = 0;
+		var o1 = new object[Size];
+		var o2 = new object[size];
+		var o3 = new object[GetSize()];
+		var s1 = new string[Size];
+		var s2 = new string[size];
+		var s3 = new string[GetSize()];
+		var i1 = new int[Size];
+		var i2 = new int[size];
+		var i3 = new int[GetSize()];
+		var ni1 = new int?[Size];
+		var ni2 = new int?[size];
+		var ni3 = new int?[GetSize()];
+
+		var t1 = new T[Size];
+		var t2 = new T[size];
+		var t3 = new T[GetSize()];
+	}
+}

--- a/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
@@ -135,10 +135,13 @@ namespace WTG.Analyzers.TestFramework
 					CancellationToken.None);
 
 				var fix = await batcher.GetFixAsync(context).ConfigureAwait(false);
-				if (fix != null)
+
+				if (fix == null)
 				{
-					document = await ApplyFixAsync(document, fix).ConfigureAwait(false);
+					return document;
 				}
+
+				document = await ApplyFixAsync(document, fix).ConfigureAwait(false);
 				analyzerDiagnostics = FilterDiagnostics(await DiagnosticUtils.GetDiagnosticsAsync(Analyzer, new[] { document }).ConfigureAwait(false));
 
 				var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(false));

--- a/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
@@ -135,7 +135,10 @@ namespace WTG.Analyzers.TestFramework
 					CancellationToken.None);
 
 				var fix = await batcher.GetFixAsync(context).ConfigureAwait(false);
-				document = await ApplyFixAsync(document, fix).ConfigureAwait(false);
+				if (fix != null)
+				{
+					document = await ApplyFixAsync(document, fix).ConfigureAwait(false);
+				}
 				analyzerDiagnostics = FilterDiagnostics(await DiagnosticUtils.GetDiagnosticsAsync(Analyzer, new[] { document }).ConfigureAwait(false));
 
 				var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document).ConfigureAwait(false));

--- a/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
@@ -99,7 +99,16 @@ namespace WTG.Analyzers
 		{
 			switch (value)
 			{
-				case sbyte s:
+				case int s:
+					return s == 0;
+
+				case uint s:
+					return s == 0;
+
+				case long s:
+					return s == 0;
+
+				case ulong s:
 					return s == 0;
 
 				case byte s:
@@ -111,16 +120,7 @@ namespace WTG.Analyzers
 				case ushort s:
 					return s == 0;
 
-				case int s:
-					return s == 0;
-
-				case uint s:
-					return s == 0;
-
-				case long s:
-					return s == 0;
-
-				case ulong s:
+				case sbyte s:
 					return s == 0;
 
 				case char s:

--- a/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
@@ -61,7 +61,14 @@ namespace WTG.Analyzers
 				switch (size.Kind())
 				{
 					case SyntaxKind.OmittedArraySizeExpression:
-						continue;
+						if (syntax.Initializer == null)
+						{
+							// If there's an initializer, we check with the initializer expression count below.
+							// If there's no initializer, this is a compiler error anyhow, so don't bother the
+							// developer with an analyzer result.
+							return;
+						}
+						break;
 
 					case SyntaxKind.CharacterLiteralExpression:
 					case SyntaxKind.NumericLiteralExpression:

--- a/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
@@ -1,0 +1,77 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class ArrayAnalyzer : DiagnosticAnalyzer
+	{
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rules.PreferArrayEmptyOverNewArrayConstructionRule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction(CompilationStart);
+		}
+
+		static void CompilationStart(CompilationStartAnalysisContext context)
+		{
+			var cache = new FileDetailCache();
+
+			context.RegisterSyntaxNodeAction(
+				c => Analyze(c, cache),
+				SyntaxKind.ArrayCreationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context, FileDetailCache cache)
+		{
+			if (cache.IsGenerated(context.SemanticModel.SyntaxTree, context.CancellationToken))
+			{
+				return;
+			}
+
+			var syntax = (ArrayCreationExpressionSyntax)context.Node;
+
+			if (syntax.FirstAncestorOrSelf<AttributeArgumentSyntax>() != null)
+			{
+				// Ignore empty arrays in attributes. Array.Empty<T>() cannot be used here.
+				return;
+			}
+
+			var ranks = syntax.Type.RankSpecifiers;
+			if (ranks.Count != 1)
+			{
+				// Ignore jagged arrays.
+				return;
+			}
+
+			var sizes = ranks[0].Sizes;
+
+			if (sizes.Count != 1)
+			{
+				// Ignore multi-dimensional arrays.
+				return;
+			}
+
+			var size = sizes[0];
+			if (size.Kind() != SyntaxKind.NumericLiteralExpression)
+			{
+				// Ignore dynamically sized arrays.
+				return;
+			}
+
+			var literal = (LiteralExpressionSyntax)size;
+			if (literal.Token.Text != "0")
+			{
+				// Ignore statically sized arrays that are not empty;
+				return;
+			}
+
+			context.ReportDiagnostic(Rules.CreatePreferArrayEmptyOverNewArrayConstructionDiagnostic(context.Node.GetLocation()));
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
@@ -49,36 +49,34 @@ namespace WTG.Analyzers
 				return;
 			}
 
-			foreach (var rank in ranks)
+			var rank = ranks[0];
+			if (rank.Sizes.Count != 1)
 			{
-				if (rank.Sizes.Count != 1)
+				// Ignore multi-dimensional top-level arrays.
+				return;
+			}
+
+			foreach (var size in rank.Sizes)
+			{
+				switch (size.Kind())
 				{
-					// Ignore multi-dimensional arrays.
-					return;
-				}
+					case SyntaxKind.OmittedArraySizeExpression:
+						continue;
 
-				foreach (var size in rank.Sizes)
-				{
-					switch (size.Kind())
-					{
-						case SyntaxKind.OmittedArraySizeExpression:
-							continue;
-
-						case SyntaxKind.CharacterLiteralExpression:
-						case SyntaxKind.NumericLiteralExpression:
-						case SyntaxKind.CastExpression:
-						case SyntaxKind.UnaryMinusExpression:
-						case SyntaxKind.UnaryPlusExpression:
-							var constant = context.SemanticModel.GetConstantValue(size, context.CancellationToken);
-							if (constant.HasValue && !IsZeroLiteral(constant.Value))
-							{
-								return;
-							}
-							break;
-
-						default:
+					case SyntaxKind.CharacterLiteralExpression:
+					case SyntaxKind.NumericLiteralExpression:
+					case SyntaxKind.CastExpression:
+					case SyntaxKind.UnaryMinusExpression:
+					case SyntaxKind.UnaryPlusExpression:
+						var constant = context.SemanticModel.GetConstantValue(size, context.CancellationToken);
+						if (constant.HasValue && !IsZeroLiteral(constant.Value))
+						{
 							return;
-					}
+						}
+						break;
+
+					default:
+						return;
 				}
 			}
 

--- a/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ArrayCodeFixProvider))]
+	[Shared]
+	public sealed class ArrayCodeFixProvider : CodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(Rules.PreferArrayEmptyOverNewArrayConstructionDiagnosticID);
+
+		public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public override Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var diagnostic = context.Diagnostics.First();
+
+			switch (diagnostic.Id)
+			{
+				case Rules.PreferArrayEmptyOverNewArrayConstructionDiagnosticID:
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: "Change to Array.Empty<T>()",
+							createChangedDocument: c => ReplaceWithArrayEmpty(context.Document, diagnostic, c),
+							equivalenceKey: "ChangeToArrayEmptyT"),
+						diagnostic: diagnostic);
+					break;
+			}
+
+			return Task.CompletedTask;
+		}
+
+		static async Task<Document> ReplaceWithArrayEmpty(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var diagnosticSpan = diagnostic.Location.SourceSpan;
+			var node = root.FindNode(diagnosticSpan);
+			var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+			if (node.Kind() == SyntaxKind.ArrayCreationExpression)
+			{
+				var syntax = (ArrayCreationExpressionSyntax)node;
+
+				document = document.WithSyntaxRoot(
+					root.ReplaceNode(
+						node,
+						CreateArrayEmptyInvocation(
+							syntax.Type.ElementType,
+							CanUseTypeShortName(model, node.GetLocation(), "System.Array", "Array"))));
+			}
+
+			return document;
+		}
+
+		static bool CanUseTypeShortName(SemanticModel model, Location location, string typeFullName, string shortName)
+		{
+			var symbols = model.LookupSymbols(location.SourceSpan.Start, null, shortName);
+			if (symbols.Length == 0)
+			{
+				return false;
+			}
+
+			var symbol = symbols[0];
+			if (symbol.Kind != SymbolKind.NamedType)
+			{
+				return false;
+			}
+
+			var namedSymbol = (INamedTypeSymbol)symbol;
+			return namedSymbol.IsMatch(typeFullName);
+		}
+
+		static InvocationExpressionSyntax CreateArrayEmptyInvocation(TypeSyntax elementType, bool canUseShortName)
+		{
+			ExpressionSyntax arrayIdentifier;
+
+			if (canUseShortName)
+			{
+				arrayIdentifier = SyntaxFactory.IdentifierName("Array");
+			}
+			else
+			{
+				arrayIdentifier = SyntaxFactory.MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					SyntaxFactory.IdentifierName("System"),
+					SyntaxFactory.IdentifierName("Array"));
+			}
+
+			return SyntaxFactory.InvocationExpression(
+				SyntaxFactory.MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					arrayIdentifier,
+					SyntaxFactory.GenericName(
+						SyntaxFactory.Identifier("Empty"))
+					.WithTypeArgumentList(
+						SyntaxFactory.TypeArgumentList(
+							SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+								elementType)))));
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
@@ -61,7 +61,8 @@ namespace WTG.Analyzers
 					root.ReplaceNode(
 						node,
 						CreateArrayEmptyInvocation(
-							arrayType)));
+							arrayType.WithoutTrivia())
+							.WithTriviaFrom(syntax)));
 			}
 
 			return document;

--- a/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
@@ -50,11 +50,18 @@ namespace WTG.Analyzers
 			{
 				var syntax = (ArrayCreationExpressionSyntax)node;
 
+				var arrayType = syntax.Type.ElementType;
+				if (syntax.Type.RankSpecifiers.Count > 1)
+				{
+					var specifiers = syntax.Type.RankSpecifiers.RemoveAt(0);
+					arrayType = SyntaxFactory.ArrayType(arrayType).WithRankSpecifiers(specifiers);
+				}
+
 				document = document.WithSyntaxRoot(
 					root.ReplaceNode(
 						node,
 						CreateArrayEmptyInvocation(
-							syntax.Type.ElementType)));
+							arrayType)));
 			}
 
 			return document;

--- a/WTG.Analyzers/Rules/Rules.g.cs
+++ b/WTG.Analyzers/Rules/Rules.g.cs
@@ -26,6 +26,7 @@ namespace WTG.Analyzers
 		public const string RemovedOrphanedSuppressionsDiagnosticID = "WTG3001";
 		public const string PreferDirectMemberAccessOverLinqDiagnosticID = "WTG3002";
 		public const string PreferDirectMemberAccessOverLinqInAnExpressionDiagnosticID = "WTG3003";
+		public const string PreferArrayEmptyOverNewArrayConstructionDiagnosticID = "WTG3004";
 		public const string DoNotNestRegionsDiagnosticID = "WTG3101";
 		public const string RegionsShouldNotSplitStructuresDiagnosticID = "WTG3102";
 		public const string ConditionalCompilationDirectivesShouldNotSplitStructuresDiagnosticID = "WTG3103";
@@ -241,6 +242,15 @@ namespace WTG.Analyzers
 			isEnabledByDefault: true,
 			description: "Don't use linq extension methods when there is a better alternative.");
 
+		public static readonly DiagnosticDescriptor PreferArrayEmptyOverNewArrayConstructionRule = new DiagnosticDescriptor(
+			PreferArrayEmptyOverNewArrayConstructionDiagnosticID,
+			"Prefer Array.Empty<T>() over creating a new empty array.",
+			"Prefer to use Array.Empty<T>() instead of creating a new empty array.",
+			DecruftificationCategory,
+			DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: "Array.Empty<T>() caches the array internally, so you can typically use a pre-existing immutable object instead of creating a new one.");
+
 		public static readonly DiagnosticDescriptor DoNotNestRegionsRule = new DiagnosticDescriptor(
 			DoNotNestRegionsDiagnosticID,
 			"Do not nest regions.",
@@ -426,6 +436,14 @@ namespace WTG.Analyzers
 		public static Diagnostic CreatePreferDirectMemberAccessOverLinqInAnExpression_UseIndexerDiagnostic(Location location, object extensionName, object sourceTypeName)
 		{
 			return Diagnostic.Create(PreferDirectMemberAccessOverLinqInAnExpression_UseIndexerRule, location, extensionName, sourceTypeName);
+		}
+
+		/// <summary>
+		/// Prefer to use Array.Empty<T>() instead of creating a new empty array.
+		/// </summary>
+		public static Diagnostic CreatePreferArrayEmptyOverNewArrayConstructionDiagnostic(Location location)
+		{
+			return Diagnostic.Create(PreferArrayEmptyOverNewArrayConstructionRule, location);
 		}
 
 		/// <summary>

--- a/WTG.Analyzers/Rules/Rules.xml
+++ b/WTG.Analyzers/Rules/Rules.xml
@@ -115,6 +115,11 @@
 			<message name="UseIndexer">Don't use the {extensionName} extension method on a source of type '{sourceTypeName}', use the indexer instead.</message>
 			<description>Don't use linq extension methods when there is a better alternative.</description>
 		</rule>
+		<rule id="4" name="PreferArrayEmptyOverNewArrayConstruction" severity="Info">
+			<title>Prefer Array.Empty&lt;T&gt;() over creating a new empty array.</title>
+			<message>Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array.</message>
+			<description>Array.Empty&lt;T&gt;() caches the array internally, so you can typically use a pre-existing immutable object instead of creating a new one.</description>
+		</rule>
 	</category>
 	<category name="Maintainability" id="3100">
 		<rule id="1" name="DoNotNestRegions" severity="Info">

--- a/WTG.Analyzers/build/WarnAll.ruleset
+++ b/WTG.Analyzers/build/WarnAll.ruleset
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="WTGAnalyzersRuleSet" ToolsVersion="14.0">
 	<Rules AnalyzerId="WTG.Analyzers" RuleNamespace="WTG.Analyzers">
 		<!-- CodingConvention -->
@@ -23,6 +23,7 @@
 		<Rule Id="WTG3001" Action="Warning" />
 		<Rule Id="WTG3002" Action="Warning" />
 		<Rule Id="WTG3003" Action="Warning" />
+		<Rule Id="WTG3004" Action="Warning" />
 
 		<!-- Maintainability -->
 		<Rule Id="WTG3101" Action="Warning" />


### PR DESCRIPTION
**Analyzer:**

- Generates a diagnostic on `new T[0]`.
- Ignores multi-dimensional arrays
- Ignores jagged arrays
- Ignores arrays created in attributes, where function calls are not available.

**Code Fix:**

- Where `System.Array` is in scope, replaces `new T[0]` with `Array.Empty<T>()`
- Where `System.Array` is not in scope, replaces `new T[0]` with `System.Array.Empty<T>()`.

I couldn't find a sane and simple way to insert a using for `System`, and also don't really want to have to deal with that in a source file where `Array` is ambiguous.
