### PR TITLE
Fix exception in ArrayCodeFixProvider

### DIFF
--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Diagnostics.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (5,10-20)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (6,10-23)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Result.cs
@@ -1,0 +1,12 @@
+public static class Foo
+{
+	public static void StaticArrayCreator<T>()
+	{
+		Method(System.Array.Empty<int>());
+		Method(System.Array.Empty<int>());
+	}
+
+	public static void Method(int[] argument)
+	{
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/ArrayAsArgument/Source.cs
@@ -1,0 +1,12 @@
+public static class Foo
+{
+	public static void StaticArrayCreator<T>()
+	{
+		Method(new int[0]);
+		Method(new int[] { });
+	}
+
+	public static void Method(int[] argument)
+	{
+	}
+}

--- a/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayCodeFixProvider.cs
@@ -43,7 +43,7 @@ namespace WTG.Analyzers
 		{
 			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 			var diagnosticSpan = diagnostic.Location.SourceSpan;
-			var node = root.FindNode(diagnosticSpan);
+			var node = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true);
 			var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
 			if (node.Kind() == SyntaxKind.ArrayCreationExpression)


### PR DESCRIPTION
Fix exception in ArrayCodeFixProvider when an empty array is passed as an argument.