### PR TITLE
Add support for private protected.

### DIFF
--- a/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
@@ -1,18 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default." severity="Hidden">
+	<suppressId>CS0107</suppressId>
 	<diagnostic>
-		<location>Test0.cs: (23,2-9)</location>
+		<location>Test0.cs: (29,2-9)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (24,2-9)</location>
+		<location>Test0.cs: (30,2-9)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (25,2-9)</location>
+		<location>Test0.cs: (31,2-9)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (26,2-9)</location>
+		<location>Test0.cs: (32,2-9)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (27,2-9)</location>
+		<location>Test0.cs: (33,2-9)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Result.cs
+++ b/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Result.cs
@@ -20,6 +20,12 @@ public class Bob
 	protected event EventHandler ProtectedEvent;
 	protected class ProtectedClass { }
 
+	private protected string PrivateProtectedField;
+	private protected string PrivateProtectedProperty => PrivateProtectedField;
+	private protected string PrivateProtectedMethod() => PrivateProtectedField;
+	private protected event EventHandler PrivateProtectedEvent;
+	private protected class PrivateProtectedClass { }
+
 	string PrivateField;
 	string PrivateProperty => PrivateField;
 	string PrivateMethod() => PrivateField;

--- a/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Source.cs
+++ b/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Source.cs
@@ -20,6 +20,12 @@ public class Bob
 	protected event EventHandler ProtectedEvent;
 	protected class ProtectedClass { }
 
+	private protected string PrivateProtectedField;
+	private protected string PrivateProtectedProperty => PrivateProtectedField;
+	private protected string PrivateProtectedMethod() => PrivateProtectedField;
+	private protected event EventHandler PrivateProtectedEvent;
+	private protected class PrivateProtectedClass { }
+
 	private string PrivateField;
 	private string PrivateProperty => PrivateField;
 	private string PrivateMethod() => PrivateField;

--- a/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
@@ -33,6 +33,8 @@ namespace WTG.Analyzers
 			}
 
 			var list = ModifierExtractionVisitor.Instance.Visit(context.Node);
+			var hasProtected = false;
+			Location privateLocation = null;
 
 			foreach (var modifier in list)
 			{
@@ -41,7 +43,11 @@ namespace WTG.Analyzers
 				switch (kind)
 				{
 					case SyntaxKind.PrivateKeyword:
-						context.ReportDiagnostic(Rules.CreateDoNotUseThePrivateKeywordDiagnostic(modifier.GetLocation()));
+						privateLocation = modifier.GetLocation();
+						break;
+
+					case SyntaxKind.ProtectedKeyword:
+						hasProtected = true;
 						break;
 
 					case SyntaxKind.InternalKeyword:
@@ -51,6 +57,11 @@ namespace WTG.Analyzers
 						}
 						break;
 				}
+			}
+
+			if (privateLocation != null && !hasProtected)
+			{
+				context.ReportDiagnostic(Rules.CreateDoNotUseThePrivateKeywordDiagnostic(privateLocation));
 			}
 		}
 

--- a/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
@@ -33,8 +33,7 @@ namespace WTG.Analyzers
 			}
 
 			var list = ModifierExtractionVisitor.Instance.Visit(context.Node);
-			var hasProtected = false;
-			Location privateLocation = null;
+			var privateToken = default(SyntaxToken);
 
 			foreach (var modifier in list)
 			{
@@ -43,25 +42,25 @@ namespace WTG.Analyzers
 				switch (kind)
 				{
 					case SyntaxKind.PrivateKeyword:
-						privateLocation = modifier.GetLocation();
+						privateToken = modifier;
 						break;
 
 					case SyntaxKind.ProtectedKeyword:
-						hasProtected = true;
-						break;
+					case SyntaxKind.PublicKeyword:
+						return;
 
 					case SyntaxKind.InternalKeyword:
 						if (IsTopLevel(context.Node))
 						{
 							context.ReportDiagnostic(Rules.CreateDoNotUseTheInternalKeywordForTopLevelTypesDiagnostic(modifier.GetLocation()));
 						}
-						break;
+						return;
 				}
 			}
 
-			if (privateLocation != null && !hasProtected)
+			if (privateToken.Kind() == SyntaxKind.PrivateKeyword)
 			{
-				context.ReportDiagnostic(Rules.CreateDoNotUseThePrivateKeywordDiagnostic(privateLocation));
+				context.ReportDiagnostic(Rules.CreateDoNotUseThePrivateKeywordDiagnostic(privateToken.GetLocation()));
 			}
 		}
 


### PR DESCRIPTION
Now that C# 7.2 supports `private protected` we should probably make sure `private` isn't combined with `protected` before suggesting it be removed.