### PR TITLE
Copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2018 WiseTech Global
+Copyright 2016-2018 WiseTech Global
 
 Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this project except in compliance with the License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2017 WiseTech Global
+Copyright 2018 WiseTech Global
 
 Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this project except in compliance with the License.

--- a/WTG.Analyzers.TestFramework.nuspec
+++ b/WTG.Analyzers.TestFramework.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package>
 	<metadata>
 		<id>WTG.Analyzers.TestFramework</id>
@@ -6,7 +6,7 @@
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Support library for testing Roslyn Analyzers.</description>
-		<copyright>Copyright 2017</copyright>
+		<copyright>Copyright 2018</copyright>
 		<developmentDependency>true</developmentDependency>
 	</metadata>
 

--- a/WTG.Analyzers.nuspec
+++ b/WTG.Analyzers.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
 	<metadata>
 		<id>WTG.Analyzers</id>
 		<version>2.0.2</version>

--- a/WTG.Analyzers.nuspec
+++ b/WTG.Analyzers.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package >
 	<metadata>
 		<id>WTG.Analyzers</id>
@@ -6,7 +6,7 @@
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Roslyn Code Analyzers to enforce WiseTech Global coding standards and catch common mistakes.</description>
-		<copyright>Copyright 2017</copyright>
+		<copyright>Copyright 2018</copyright>
 		<developmentDependency>true</developmentDependency>
 	</metadata>
 

--- a/build/Global.props
+++ b/build/Global.props
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<BranchRootDirectory>$(MSBuildThisFileDirectory)..</BranchRootDirectory>
 		<BranchBuildSettingsDirectory>$(BranchRootDirectory)\build\</BranchBuildSettingsDirectory>
@@ -24,7 +24,7 @@
 
 		<Company>WiseTech Global Pty Ltd</Company>
 		<Product>WTG Analyzers</Product>
-		<Copyright>Copyright © WiseTech Global 2016-2017</Copyright>
+		<Copyright>Copyright © WiseTech Global 2016-2018</Copyright>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
 	</PropertyGroup>


### PR DESCRIPTION
Updated copyright year references that were missed in #12 

These files were already specifying just a single year, so left them as such. not sure if they should be changed to 2016-2018.