### PR TITLE
Fix leading whitespace in doc-comments.

### DIFF
--- a/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Diagnostics.xml
@@ -1,17 +1,30 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG1004" message="Our coding convention is to use tabs, not spaces, you may need to fix your settings." severity="Info">
 	<diagnostic>
-		<location>Test0.cs: (6,1-5)</location>
-		<location>Test0.cs: (7,1-5)</location>
-		<location>Test0.cs: (8,1-9)</location>
-		<location>Test0.cs: (9,1-9)</location>
-		<location>Test0.cs: (10,1-5)</location>
+		<location>Test0.cs: (4,1-5)</location>
+		<location>Test0.cs: (5,1-8)</location>
+		<location>Test0.cs: (6,1-6)</location>
+
+		<location>Test0.cs: (9,1-5)</location>
+		<location>Test0.cs: (10,1-6)</location>
+		<location>Test0.cs: (11,1-6)</location>
+
 		<location>Test0.cs: (12,1-5)</location>
 		<location>Test0.cs: (13,1-5)</location>
 		<location>Test0.cs: (14,1-9)</location>
-		<location>Test0.cs: (18,1-9)</location>
-		<location>Test0.cs: (19,1-19)</location>
-		<location>Test0.cs: (20,1-19)</location>
+		<location>Test0.cs: (15,1-9)</location>
+		<location>Test0.cs: (16,1-5)</location>
+
+		<location>Test0.cs: (18,1-5)</location>
+		<location>Test0.cs: (19,1-5)</location>
+		<location>Test0.cs: (20,1-5)</location>
 		<location>Test0.cs: (21,1-5)</location>
+		<location>Test0.cs: (22,1-5)</location>
+		<location>Test0.cs: (23,1-9)</location>
+
+		<location>Test0.cs: (27,1-9)</location>
+		<location>Test0.cs: (28,1-19)</location>
+		<location>Test0.cs: (29,1-19)</location>
+		<location>Test0.cs: (30,1-5)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Result.cs
+++ b/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Result.cs
@@ -1,14 +1,23 @@
 using System;
 using System.Linq;
 
+	/**
+	   doc comment 1
+	 */
 public class ClassyBob
 {
+	/**
+	 * doc comment 2
+	 */
 	public void Bob()
 	{
 		// comment
 		Barry();
 	}
 
+	/// <summary>
+	/// doc comment 3
+	/// </summary>
 	void Barry()
 	{
 		var text = @"

--- a/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Source.cs
+++ b/WTG.Analyzers.Test/TestData/WhitespaceAnalyzer/LeadingWhitespace/Source.cs
@@ -1,14 +1,23 @@
 using System;
 using System.Linq;
 
+    /**
+       doc comment 1
+     */
 public class ClassyBob
 {
+    /**
+     * doc comment 2
+     */
     public void Bob()
     {
         // comment
         Barry();
     }
 
+    /// <summary>
+    /// doc comment 3
+    /// </summary>
     void Barry()
     {
         var text = @"

--- a/WTG.Analyzers/Analyzers/Whitespace/WhitespaceAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Whitespace/WhitespaceAnalyzer.cs
@@ -39,9 +39,9 @@ namespace WTG.Analyzers
 				switch (trivia.Kind())
 				{
 					case SyntaxKind.EndOfLineTrivia:
-						if (TryGetPreceedingTrivia(trivia, out var preceedingTrivia) && preceedingTrivia.IsKind(SyntaxKind.WhitespaceTrivia))
+						if (TryGetPrecedingTrivia(trivia, out var precedingTrivia) && precedingTrivia.IsKind(SyntaxKind.WhitespaceTrivia))
 						{
-							context.ReportDiagnostic(Rules.CreateDoNotLeaveWhitespaceOnTheEndOfTheLineDiagnostic(preceedingTrivia.GetLocation()));
+							context.ReportDiagnostic(Rules.CreateDoNotLeaveWhitespaceOnTheEndOfTheLineDiagnostic(precedingTrivia.GetLocation()));
 						}
 
 						if (trivia.ToString() != "\r\n")
@@ -102,7 +102,7 @@ namespace WTG.Analyzers
 			}
 		}
 
-		static bool TryGetPreceedingTrivia(SyntaxTrivia trivia, out SyntaxTrivia preceedingTrivia)
+		static bool TryGetPrecedingTrivia(SyntaxTrivia trivia, out SyntaxTrivia precedingTrivia)
 		{
 			var token = trivia.Token;
 			var list = token.TrailingTrivia;
@@ -115,31 +115,28 @@ namespace WTG.Analyzers
 
 				if (index < 0)
 				{
-					preceedingTrivia = default(SyntaxTrivia);
+					precedingTrivia = default(SyntaxTrivia);
 					return false;
 				}
 			}
 
 			if (index > 0)
 			{
-				preceedingTrivia = list[index - 1];
+				precedingTrivia = list[index - 1];
 				return true;
 			}
 
-			preceedingTrivia = default(SyntaxTrivia);
+			precedingTrivia = default(SyntaxTrivia);
 			return false;
 		}
 
 		static string LeadingWhitespace(string text)
 		{
-			if (text.Length != 0)
+			for (var n = 0; n < text.Length; n++)
 			{
-				for (var n = 0; n < text.Length; n++)
+				if (!char.IsWhiteSpace(text, n))
 				{
-					if (!char.IsWhiteSpace(text, n))
-					{
-						return text.Substring(0, n);
-					}
+					return text.Substring(0, n);
 				}
 			}
 


### PR DESCRIPTION
If a doc-comment spans more than one line, only the first line is being checked by WTG1004, this change fixes that.