### PR TITLE
Bump version to 2.0.4, add deployment to gallery when tagged

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ artifacts:
   - path: bin\WTG.Analyzers.$(WTG_ANALYZERS_VERSION).nupkg
   - path: bin\WTG.Analyzers.TestFramework.$(WTG_ANALYZERS_VERSION).nupkg
 
- deploy:
+deploy:
   - provider: NuGet
     api_key:
       secure: 'N0UpuDdHhEWIREEAXYDSNqJqpNIBq5c5lcIvpoAzvQA5A7AdCH2/l/b4VNWipmLk'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.3.{build}
+version: 2.0.4.{build}
 
 skip_branch_with_pr: true
 os: Visual Studio 2017
@@ -14,7 +14,7 @@ configuration:
   - Release
 
 environment:
-  WTG_ANALYZERS_VERSION: 2.0.3
+  WTG_ANALYZERS_VERSION: 2.0.4
 
 init:
   - git config --global core.autocrlf true
@@ -39,3 +39,13 @@ test:
 artifacts:
   - path: bin\WTG.Analyzers.$(WTG_ANALYZERS_VERSION).nupkg
   - path: bin\WTG.Analyzers.TestFramework.$(WTG_ANALYZERS_VERSION).nupkg
+
+ deploy:
+  - provider: NuGet
+    api_key:
+      secure: 'N0UpuDdHhEWIREEAXYDSNqJqpNIBq5c5lcIvpoAzvQA5A7AdCH2/l/b4VNWipmLk'
+    skip_symbols: false
+    artifact: /.*\.nupkg/
+    on:
+      configuration: Release
+      appveyor_repo_tag: true

--- a/build/Global.props
+++ b/build/Global.props
@@ -20,7 +20,7 @@
 		  - Revision should be incremented whenever you want to publish a new version.
 		  -->
 		<Version Condition="'$(APPVEYOR_BUILD_VERSION)' != ''">$(APPVEYOR_BUILD_VERSION)</Version>
-		<Version Condition="'$(Version)' == ''">2.0.3.0</Version>
+		<Version Condition="'$(Version)' == ''">2.0.4.0</Version>
 
 		<Company>WiseTech Global Pty Ltd</Company>
 		<Product>WTG Analyzers</Product>


### PR DESCRIPTION
Longer term, I need to find a way to get rid of `WTG_ANALYZERS_VERSION`.

Short term, I've just bumped it along with the rest.