### PR TITLE
Normalize ExportCodeFixProviderAttribute.Name.

### DIFF
--- a/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Composition;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -43,6 +44,14 @@ namespace WTG.Analyzers.Test
 			var analyzer = new TAnalyzer();
 			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, string.Empty).ConfigureAwait(false);
 			Assert.That(diagnostics, IsDiagnostic.Empty);
+		}
+
+		[Test]
+		public void CodeFixProviderAttribute()
+		{
+			var codeFixType = typeof(TCodeFix);
+			var att = codeFixType.GetCustomAttribute<ExportCodeFixProviderAttribute>();
+			Assert.That(att, Is.Not.Null & Has.Property(nameof(att.Name)).EqualTo(codeFixType.Name));
 		}
 
 		[Test]

--- a/WTG.Analyzers/Analyzers/BooleanComparison/BooleanComparisonCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/BooleanComparison/BooleanComparisonCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -12,7 +12,7 @@ using WTG.Analyzers.Utils;
 
 namespace WTG.Analyzers
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncCodeFixProvider))]
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BooleanComparisonCodeFixProvider))]
 	[Shared]
 	public sealed class BooleanComparisonCodeFixProvider : CodeFixProvider
 	{

--- a/WTG.Analyzers/Analyzers/Linq/LinqCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Linq/LinqCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace WTG.Analyzers
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(VarCodeFixProvider))]
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LinqCodeFixProvider))]
 	[Shared]
 	public sealed class LinqCodeFixProvider : CodeFixProvider
 	{

--- a/WTG.Analyzers/Analyzers/RegionDirective/RegionDirectiveCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/RegionDirective/RegionDirectiveCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace WTG.Analyzers
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(VarCodeFixProvider))]
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RegionDirectiveCodeFixProvider))]
 	[Shared]
 	public sealed class RegionDirectiveCodeFixProvider : CodeFixProvider
 	{


### PR DESCRIPTION
Just cleaned up a few copy-paste issues.