### PR TITLE
Fixed false positive on non-constant size.

### DIFF
--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/SizedArrayCreation/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/SizedArrayCreation/Source.cs
@@ -31,5 +31,9 @@ public static class Foo
 		var t1 = new T[Size];
 		var t2 = new T[size];
 		var t3 = new T[GetSize()];
+
+		var u1 = new T[(int)size];
+		var u2 = new T[(size)];
+		var u3 = new T[+size];
 	}
 }

--- a/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Array/ArrayAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -75,8 +76,7 @@ namespace WTG.Analyzers
 					case SyntaxKind.CastExpression:
 					case SyntaxKind.UnaryMinusExpression:
 					case SyntaxKind.UnaryPlusExpression:
-						var constant = context.SemanticModel.GetConstantValue(size, context.CancellationToken);
-						if (constant.HasValue && !IsZeroLiteral(constant.Value))
+						if (!IsConstantZero(context.SemanticModel, size, context.CancellationToken))
 						{
 							return;
 						}
@@ -93,6 +93,13 @@ namespace WTG.Analyzers
 			}
 
 			context.ReportDiagnostic(Rules.CreatePreferArrayEmptyOverNewArrayConstructionDiagnostic(context.Node.GetLocation()));
+		}
+
+		static bool IsConstantZero(SemanticModel model, ExpressionSyntax expression, CancellationToken cancellationToken)
+		{
+			var constant = model.GetConstantValue(expression, cancellationToken);
+
+			return constant.HasValue && IsZeroLiteral(constant.Value);
 		}
 
 		static bool IsZeroLiteral(object value)


### PR DESCRIPTION
This change addresses the false-positive in WTG3004 when the size is provided by a non-constant value that has been cast or where a +/- unary operator is applied.