### PR TITLE
Bump version number to 2.0.5

### DIFF
--- a/WTG.Analyzers.TestFramework.nuspec
+++ b/WTG.Analyzers.TestFramework.nuspec
@@ -2,7 +2,6 @@
 <package>
 	<metadata>
 		<id>WTG.Analyzers.TestFramework</id>
-		<version>2.0.2</version>
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Support library for testing Roslyn Analyzers.</description>

--- a/WTG.Analyzers.TestFramework.nuspec
+++ b/WTG.Analyzers.TestFramework.nuspec
@@ -2,6 +2,7 @@
 <package>
 	<metadata>
 		<id>WTG.Analyzers.TestFramework</id>
+		<version>2.0.5</version>
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Support library for testing Roslyn Analyzers.</description>

--- a/WTG.Analyzers.nuspec
+++ b/WTG.Analyzers.nuspec
@@ -2,6 +2,7 @@
 <package>
 	<metadata>
 		<id>WTG.Analyzers</id>
+		<version>2.0.5</version>
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Roslyn Code Analyzers to enforce WiseTech Global coding standards and catch common mistakes.</description>

--- a/WTG.Analyzers.nuspec
+++ b/WTG.Analyzers.nuspec
@@ -2,7 +2,6 @@
 <package>
 	<metadata>
 		<id>WTG.Analyzers</id>
-		<version>2.0.2</version>
 		<authors>WiseTech Global</authors>
 		<owners>WiseTech Global</owners>
 		<description>Roslyn Code Analyzers to enforce WiseTech Global coding standards and catch common mistakes.</description>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.4.{build}
+version: 2.0.5.{build}
 
 skip_branch_with_pr: true
 os: Visual Studio 2017
@@ -14,7 +14,7 @@ configuration:
   - Release
 
 environment:
-  WTG_ANALYZERS_VERSION: 2.0.4
+  WTG_ANALYZERS_VERSION: 2.0.5
 
 init:
   - git config --global core.autocrlf true

--- a/build/Global.props
+++ b/build/Global.props
@@ -20,7 +20,7 @@
 		  - Revision should be incremented whenever you want to publish a new version.
 		  -->
 		<Version Condition="'$(APPVEYOR_BUILD_VERSION)' != ''">$(APPVEYOR_BUILD_VERSION)</Version>
-		<Version Condition="'$(Version)' == ''">2.0.4.0</Version>
+		<Version Condition="'$(Version)' == ''">2.0.5.0</Version>
 
 		<Company>WiseTech Global Pty Ltd</Company>
 		<Product>WTG Analyzers</Product>


### PR DESCRIPTION
Bump version number for new release.

Removed version numbers from the nuspec files, it's out of date and gets overridden anyway.