### PR TITLE
Fixed race in nameof cache.

### DIFF
--- a/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
+++ b/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
@@ -81,6 +81,12 @@ namespace WTG.Analyzers.Utils.Test
 		}
 
 		[Test]
+		public void Nameof_Cached()
+		{
+			Assert.That(ExpressionSyntaxFactory.Nameof, Is.SameAs(ExpressionSyntaxFactory.Nameof));
+		}
+
+		[Test]
 		public void CreateElementAccess()
 		{
 			var collectionExpression = SyntaxFactory.IdentifierName("collection");

--- a/WTG.Analyzers.Utils/ExpressionSyntaxFactory.cs
+++ b/WTG.Analyzers.Utils/ExpressionSyntaxFactory.cs
@@ -20,7 +20,7 @@ namespace WTG.Analyzers.Utils
 					// Error CS0103: The name 'nameof' does not exist in the current context
 					var invoke = (InvocationExpressionSyntax)SyntaxFactory.ParseExpression("nameof(A)");
 					var identifier = (IdentifierNameSyntax)invoke.Expression.WithoutTrivia();
-					nameofSyntax = Interlocked.CompareExchange(ref nameofSyntax, identifier, null) ?? identifier;
+					Interlocked.CompareExchange(ref nameofSyntax, identifier, null);
 				}
 
 				return nameofSyntax;


### PR DESCRIPTION
Well that was embarrassing.

We use `Interlocked.CompareExchange` to avoid a race condition, but then proceed to re-introduce the effect of the race. (the severity is very low though, it just means we may create more objects than we really need to.)