### PR TITLE
WTG3004: Warn on array initializers.

### DIFF
--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Diagnostics.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3004" message="Prefer to use Array.Empty&lt;T&gt;() instead of creating a new empty array." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,13-16)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (8,15-18)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Result.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Result.cs
@@ -1,0 +1,10 @@
+using System;
+
+public static class Foo
+{
+	public static void StaticArrayCreator()
+	{
+		int[] x = Array.Empty<int>();
+		int[][] y = Array.Empty<int[]>();
+	}
+}

--- a/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ArrayAnalyzer/InitializerExpression/Source.cs
@@ -1,0 +1,10 @@
+using System;
+
+public static class Foo
+{
+	public static void StaticArrayCreator()
+	{
+		int[] x = { };
+		int[][] y = { };
+	}
+}


### PR DESCRIPTION
Fixes #46.

There has to be a better way to do the `.Parent.Parent.Parent` bit somehow...