### PR TITLE
Avoid fights with visual studio.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿# http://editorconfig.org/#file-format-details
+# http://editorconfig.org/#file-format-details
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 # https://github.com/dotnet/roslyn/pull/15020
 
@@ -110,7 +110,5 @@ csharp_space_between_square_brackets = false
 [*.{csproj,vcxproj,vcxproj.filters,fsproj,nativeproj,locproj}]
 indent_style = space
 indent_size = 2
-
-[*.yaml]
-indent_style = space
-indent_size = 2
+insert_final_newline = false
+charset = utf-8-bom

--- a/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
+++ b/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Utils</AssemblyTitle>

--- a/WTG.Analyzers/WTG.Analyzers.csproj
+++ b/WTG.Analyzers/WTG.Analyzers.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers</AssemblyTitle>


### PR DESCRIPTION
Visual studio ignores `.editorconfig` when editing the project file via 'Solution Explorer', but not when editing as an xml file. This change sets the settings for project files to match what `Solution Explorer` uses anyway so that the saved content doesn't keep jumping back and forth.