### PR TITLE
Improved bool inversion.

### DIFF
--- a/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
+++ b/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
@@ -11,6 +11,28 @@ namespace WTG.Analyzers.Utils.Test
 	class ExpressionSyntaxFactoryTest
 	{
 		[TestCase("42", ExpectedResult = "!42")]
+		[TestCase("!42", ExpectedResult = "42")]
+		[TestCase("identifier", ExpectedResult = "!identifier")]
+		[TestCase("identifier1.identifier2", ExpectedResult = "!identifier1.identifier2")]
+		[TestCase("a && b", ExpectedResult = "!(a && b)")]
+		[TestCase("a || b", ExpectedResult = "!(a || b)")]
+		[TestCase("a == b", ExpectedResult = "a != b")]
+		[TestCase("a != b", ExpectedResult = "a == b")]
+		[TestCase("a > b", ExpectedResult = "a <= b")]
+		[TestCase("a < b", ExpectedResult = "a >= b")]
+		[TestCase("a >= b", ExpectedResult = "a < b")]
+		[TestCase("a <= b", ExpectedResult = "a > b")]
+		[TestCase("true", ExpectedResult = "false")]
+		[TestCase("false", ExpectedResult = "true")]
+		public string InvertBoolExpression(string expressionString)
+		{
+			var baseExpression = SyntaxFactory.ParseExpression(expressionString);
+			var expression = ExpressionSyntaxFactory.InvertBoolExpression(baseExpression);
+			return expression.ToFullString();
+		}
+
+		[TestCase("42", ExpectedResult = "!42")]
+		[TestCase("~42", ExpectedResult = "!~42")]
 		[TestCase("identifier", ExpectedResult = "!identifier")]
 		[TestCase("identifier1.identifier2", ExpectedResult = "!identifier1.identifier2")]
 		[TestCase("21 * 2", ExpectedResult = "!(21 * 2)")]

--- a/WTG.Analyzers.Utils/ExpressionRemover.cs
+++ b/WTG.Analyzers.Utils/ExpressionRemover.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -101,7 +100,7 @@ namespace WTG.Analyzers.Utils
 						}
 						else if (whenTrue.IsKind(SyntaxKind.FalseLiteralExpression))
 						{
-							newExpression = ExpressionSyntaxFactory.LogicalNot(newExpression);
+							newExpression = ExpressionSyntaxFactory.InvertBoolExpression(newExpression);
 						}
 
 						return newExpression.WithTriviaFrom(node);
@@ -119,7 +118,7 @@ namespace WTG.Analyzers.Utils
 					{
 						opKind = SyntaxKind.AmpersandAmpersandToken;
 						nodeKind = SyntaxKind.LogicalAndExpression;
-						conditionExpression = ExpressionSyntaxFactory.LogicalNot(conditionExpression);
+						conditionExpression = ExpressionSyntaxFactory.InvertBoolExpression(conditionExpression);
 					}
 
 					return SyntaxFactory.BinaryExpression(
@@ -139,7 +138,7 @@ namespace WTG.Analyzers.Utils
 					{
 						opKind = SyntaxKind.BarBarToken;
 						nodeKind = SyntaxKind.LogicalOrExpression;
-						conditionExpression = ExpressionSyntaxFactory.LogicalNot(conditionExpression);
+						conditionExpression = ExpressionSyntaxFactory.InvertBoolExpression(conditionExpression);
 					}
 					else
 					{

--- a/WTG.Analyzers/Analyzers/BooleanComparison/BooleanComparisonCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/BooleanComparison/BooleanComparisonCodeFixProvider.cs
@@ -61,7 +61,7 @@ namespace WTG.Analyzers
 
 			if (isEquality != comparand)
 			{
-				newNode = ExpressionSyntaxFactory.LogicalNot(newNode);
+				newNode = ExpressionSyntaxFactory.InvertBoolExpression(newNode);
 			}
 
 			return document.WithSyntaxRoot(


### PR DESCRIPTION
There are a number of places where the code fixes need to invert a boolean expression, currently we do this by simply applying the `!` operator.

This change considers the expression to be inverted so that, for example:
* `a != null` -> `a == null`
* `!string.IsNullOrEmpty(a)` -> `string.IsNullOrEmpty(a)`
* `a >= 0` -> `a < 0`