### PR TITLE
README.md AppVeyor links to master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WiseTech Global Analyzers
 
-[![Build](https://img.shields.io/appveyor/ci/WiseTechGlobal/wtg-analyzers/master.svg)](https://ci.appveyor.com/project/WiseTechGlobal/wtg-analyzers)
-[![Tests](https://img.shields.io/appveyor/tests/WiseTechGlobal/wtg-analyzers/master.svg)](https://ci.appveyor.com/project/WiseTechGlobal/wtg-analyzers)
+[![Build](https://img.shields.io/appveyor/ci/WiseTechGlobal/wtg-analyzers/master.svg)](https://ci.appveyor.com/project/WiseTechGlobal/wtg-analyzers/branch/master)
+[![Tests](https://img.shields.io/appveyor/tests/WiseTechGlobal/wtg-analyzers/master.svg)](https://ci.appveyor.com/project/WiseTechGlobal/wtg-analyzers/branch/master)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/WiseTechGlobal/WTG.Analyzers/blob/master/LICENSE.md)
 [![NuGet](https://img.shields.io/nuget/v/WTG.Analyzers.svg)](http://nuget.org/packages/WTG.Analyzers)
 


### PR DESCRIPTION
AppVeyor links in README.md should reference the latest build _on master_ rather than latest build overall.