### PR TITLE
Code contracts revised

### DIFF
--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/Generic/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/Generic/Diagnostics.xml
@@ -13,6 +13,6 @@
 		<location>Test0.cs: (29,3-68)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (36,3-89)</location>
+		<location>Test0.cs: (36,3-96)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/Generic/Source.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/Generic/Source.cs
@@ -33,7 +33,7 @@ public class Bob
 
 	public void Method5(string str)
 	{
-		Contract.Requires<ArgumentException>(!string.IsNullOrEmpty(str), "Must provide str.");
+		Contract.Requires<System.ArgumentException>(!string.IsNullOrEmpty(str), "Must provide str.");
 
 		str.GetType();
 	}

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Diagnostics.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG2004" message="This project does not use Code Contracts." severity="Warning">
+	<diagnostic>
+		<location>Test0.cs: (12,4-33)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (13,4-38)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (22,4-33)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (23,4-38)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (32,4-33)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (33,4-38)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (42,4-33)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (43,4-38)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Result.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Result.cs
@@ -1,0 +1,40 @@
+using System;
+
+public class Bob
+{
+	public void LocalMethod(Action action)
+	{
+		DoStuff(action);
+
+		void DoStuff(Action x)
+		{
+			x();
+		}
+	}
+
+	public void AnonymousMethod(Action action)
+	{
+		X(delegate (Action x)
+		{
+			x();
+		});
+	}
+
+	public void SimpleLambda(Action action)
+	{
+		X(x =>
+		{
+			x();
+		});
+	}
+
+	public void PLambda(Action action)
+	{
+		X((x) =>
+		{
+			x();
+		});
+	}
+
+	void X(Action<Action> action) => action(null);
+}

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Source.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/NestedMethods/Source.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics.Contracts;
+
+public class Bob
+{
+	public void LocalMethod(Action action)
+	{
+		DoStuff(action);
+
+		void DoStuff(Action x)
+		{
+			Contract.Requires(x != null);
+			Contract.Requires(action != null);
+			x();
+		}
+	}
+
+	public void AnonymousMethod(Action action)
+	{
+		X(delegate (Action x)
+		{
+			Contract.Requires(x != null);
+			Contract.Requires(action != null);
+			x();
+		});
+	}
+
+	public void SimpleLambda(Action action)
+	{
+		X(x =>
+		{
+			Contract.Requires(x != null);
+			Contract.Requires(action != null);
+			x();
+		});
+	}
+
+	public void PLambda(Action action)
+	{
+		X((x) =>
+		{
+			Contract.Requires(x != null);
+			Contract.Requires(action != null);
+			x();
+		});
+	}
+
+	void X(Action<Action> action) => action(null);
+}

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
@@ -89,6 +89,12 @@ namespace WTG.Analyzers
 					case SyntaxKind.ClassDeclaration:
 					case SyntaxKind.StructDeclaration:
 						return false;
+
+					case SyntaxKind.LocalFunctionStatement:
+					case SyntaxKind.AnonymousMethodExpression:
+					case SyntaxKind.ParenthesizedLambdaExpression:
+					case SyntaxKind.SimpleLambdaExpression:
+						return true;
 				}
 
 				node = node.Parent;

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
@@ -225,7 +225,9 @@ namespace WTG.Analyzers
 
 		public static StatementSyntax ConvertGenericRequires(InvocationExpressionSyntax invoke, Location typeLocation)
 		{
-			var exceptionType = (TypeSyntax)invoke.FindNode(typeLocation.SourceSpan);
+			var exceptionType = (TypeSyntax)invoke.FindNode(typeLocation.SourceSpan)
+				.WithAdditionalAnnotations(Simplifier.Annotation);
+
 			var arguments = invoke.ArgumentList.Arguments;
 			var condition = ExpressionSyntaxFactory.InvertBoolExpression(arguments[0].Expression);
 


### PR DESCRIPTION
* Local methods, anonymous methods and lambda expressions should be treated as 'private'.
* The exception extracted from `Requires<>` should be simplified (though, it's not moving between contexts so the benefit here is marginal at best).