### PR TITLE
Relax WTG2001 to allow literal true.

### DIFF
--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Diagnostics.xml
@@ -3,7 +3,4 @@
 	<diagnostic>
 		<location>Test0.cs: (11,39-61)</location>
 	</diagnostic>
-	<diagnostic>
-		<location>Test0.cs: (12,39-60)</location>
-	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Result.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Result.cs
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		Munch(async delegate { await Stuff(); });
 		Munch(async delegate { await Stuff(); }); // async void - not ok
-		Munch(async delegate { await Stuff(); }); // async void - not ok
+		Munch(async delegate { await Stuff().ConfigureAwait(true); });
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		AsyncMunch(async delegate { await Stuff(); });
 		AsyncMunch(async delegate { await Stuff().ConfigureAwait(false); }); // async Task - ok
-		AsyncMunch(async delegate { await Stuff().ConfigureAwait(true); }); // async Task - ok
+		AsyncMunch(async delegate { await Stuff().ConfigureAwait(true); });
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Source.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/AnonymousMethod/Source.cs
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		Munch(async delegate { await Stuff(); });
 		Munch(async delegate { await Stuff().ConfigureAwait(false); }); // async void - not ok
-		Munch(async delegate { await Stuff().ConfigureAwait(true); }); // async void - not ok
+		Munch(async delegate { await Stuff().ConfigureAwait(true); });
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		AsyncMunch(async delegate { await Stuff(); });
 		AsyncMunch(async delegate { await Stuff().ConfigureAwait(false); }); // async Task - ok
-		AsyncMunch(async delegate { await Stuff().ConfigureAwait(true); }); // async Task - ok
+		AsyncMunch(async delegate { await Stuff().ConfigureAwait(true); });
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Diagnostics.xml
@@ -1,9 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG2001" message="ConfigureAwait(false) may result in the async method resuming on a non-deterministic thread, and if an exception is then thrown, it will likely be unhandled and result in process termination." severity="Error">
 	<diagnostic>
 		<location>Test0.cs: (11,16-38)</location>
-	</diagnostic>
-	<diagnostic>
-		<location>Test0.cs: (12,16-37)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Result.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		await Stuff();
 		await Stuff(); // async void - not ok
-		await Stuff(); // async void - not ok
+		await Stuff().ConfigureAwait(true);
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		await Stuff();
 		await Stuff().ConfigureAwait(false); // async Task - ok
-		await Stuff().ConfigureAwait(true); // async Task - ok
+		await Stuff().ConfigureAwait(true);
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Source.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/DirectMethod/Source.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		await Stuff();
 		await Stuff().ConfigureAwait(false); // async void - not ok
-		await Stuff().ConfigureAwait(true); // async void - not ok
+		await Stuff().ConfigureAwait(true);
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		await Stuff();
 		await Stuff().ConfigureAwait(false); // async Task - ok
-		await Stuff().ConfigureAwait(true); // async Task - ok
+		await Stuff().ConfigureAwait(true);
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Diagnostics.xml
@@ -1,9 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG2001" message="ConfigureAwait(false) may result in the async method resuming on a non-deterministic thread, and if an exception is then thrown, it will likely be unhandled and result in process termination." severity="Error">
 	<diagnostic>
 		<location>Test0.cs: (11,34-56)</location>
-	</diagnostic>
-	<diagnostic>
-		<location>Test0.cs: (12,34-55)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Result.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		Munch(async () => await Stuff());
 		Munch(async () => await Stuff()); // async void - not ok
-		Munch(async () => await Stuff()); // async void - not ok
+		Munch(async () => await Stuff().ConfigureAwait(true));
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		AsyncMunch(async () => await Stuff());
 		AsyncMunch(async () => await Stuff().ConfigureAwait(false)); // async Task - ok
-		AsyncMunch(async () => await Stuff().ConfigureAwait(true)); // async Task - ok
+		AsyncMunch(async () => await Stuff().ConfigureAwait(true));
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Source.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/Lambda/Source.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,14 +9,14 @@ public static class Bob
 	{
 		Munch(async () => await Stuff());
 		Munch(async () => await Stuff().ConfigureAwait(false)); // async void - not ok
-		Munch(async () => await Stuff().ConfigureAwait(true)); // async void - not ok
+		Munch(async () => await Stuff().ConfigureAwait(true));
 	}
 
 	public static async Task ATMethodAsync()
 	{
 		AsyncMunch(async () => await Stuff());
 		AsyncMunch(async () => await Stuff().ConfigureAwait(false)); // async Task - ok
-		AsyncMunch(async () => await Stuff().ConfigureAwait(true)); // async Task - ok
+		AsyncMunch(async () => await Stuff().ConfigureAwait(true));
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Diagnostics.xml
@@ -1,27 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG2001" message="ConfigureAwait(false) may result in the async method resuming on a non-deterministic thread, and if an exception is then thrown, it will likely be unhandled and result in process termination." severity="Error">
 	<diagnostic>
 		<location>Test0.cs: (11,35-57)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (12,35-56)</location>
-	</diagnostic>
-	<diagnostic>
 		<location>Test0.cs: (22,35-57)</location>
-	</diagnostic>
-	<diagnostic>
-		<location>Test0.cs: (23,35-56)</location>
 	</diagnostic>
 	<diagnostic>
 		<location>Test0.cs: (33,34-56)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (34,34-55)</location>
-	</diagnostic>
-	<diagnostic>
 		<location>Test0.cs: (44,34-56)</location>
-	</diagnostic>
-	<diagnostic>
-		<location>Test0.cs: (45,34-55)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Result.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,44 +9,44 @@ public static class Bob
 	{
 		async void V1() => await Stuff();
 		async void V2() => await Stuff(); // async void - not ok
-		async void V3() => await Stuff(); // async void - not ok
+		async void V3() => await Stuff().ConfigureAwait(true);
 
 		async Task T1() => await Stuff();
 		async Task T2() => await Stuff().ConfigureAwait(false); // async Task - ok
-		async Task T3() => await Stuff().ConfigureAwait(true); // async Task - ok
+		async Task T3() => await Stuff().ConfigureAwait(true);
 	}
 
 	public static async Task ATMethodAsync1()
 	{
 		async void V1() => await Stuff();
 		async void V2() => await Stuff(); // async void - not ok
-		async void V3() => await Stuff(); // async void - not ok
+		async void V3() => await Stuff().ConfigureAwait(true);
 
 		async Task T1() => await Stuff();
 		async Task T2() => await Stuff().ConfigureAwait(false); // async Task - ok
-		async Task T3() => await Stuff().ConfigureAwait(true); // async Task - ok
+		async Task T3() => await Stuff().ConfigureAwait(true);
 	}
 
 	public static async void AVMethod2()
 	{
 		async void V1() { await Stuff(); }
 		async void V2() { await Stuff(); } // async void - not ok
-		async void V3() { await Stuff(); } // async void - not ok
+		async void V3() { await Stuff().ConfigureAwait(true); }
 
 		async Task T1() { await Stuff(); }
 		async Task T2() { await Stuff().ConfigureAwait(false); } // async Task - ok
-		async Task T3() { await Stuff().ConfigureAwait(true); } // async Task - ok
+		async Task T3() { await Stuff().ConfigureAwait(true); }
 	}
 
 	public static async Task ATMethodAsync2()
 	{
 		async void V1() { await Stuff(); }
 		async void V2() { await Stuff(); } // async void - not ok
-		async void V3() { await Stuff(); } // async void - not ok
+		async void V3() { await Stuff().ConfigureAwait(true); }
 
 		async Task T1() { await Stuff(); }
 		async Task T2() { await Stuff().ConfigureAwait(false); } // async Task - ok
-		async Task T3() { await Stuff().ConfigureAwait(true); } // async Task - ok
+		async Task T3() { await Stuff().ConfigureAwait(true); }
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Source.cs
+++ b/WTG.Analyzers.Test/TestData/AsyncAnalyzer/LocalMethod/Source.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,44 +9,44 @@ public static class Bob
 	{
 		async void V1() => await Stuff();
 		async void V2() => await Stuff().ConfigureAwait(false); // async void - not ok
-		async void V3() => await Stuff().ConfigureAwait(true); // async void - not ok
+		async void V3() => await Stuff().ConfigureAwait(true);
 
 		async Task T1() => await Stuff();
 		async Task T2() => await Stuff().ConfigureAwait(false); // async Task - ok
-		async Task T3() => await Stuff().ConfigureAwait(true); // async Task - ok
+		async Task T3() => await Stuff().ConfigureAwait(true);
 	}
 
 	public static async Task ATMethodAsync1()
 	{
 		async void V1() => await Stuff();
 		async void V2() => await Stuff().ConfigureAwait(false); // async void - not ok
-		async void V3() => await Stuff().ConfigureAwait(true); // async void - not ok
+		async void V3() => await Stuff().ConfigureAwait(true);
 
 		async Task T1() => await Stuff();
 		async Task T2() => await Stuff().ConfigureAwait(false); // async Task - ok
-		async Task T3() => await Stuff().ConfigureAwait(true); // async Task - ok
+		async Task T3() => await Stuff().ConfigureAwait(true);
 	}
 
 	public static async void AVMethod2()
 	{
 		async void V1() { await Stuff(); }
 		async void V2() { await Stuff().ConfigureAwait(false); } // async void - not ok
-		async void V3() { await Stuff().ConfigureAwait(true); } // async void - not ok
+		async void V3() { await Stuff().ConfigureAwait(true); }
 
 		async Task T1() { await Stuff(); }
 		async Task T2() { await Stuff().ConfigureAwait(false); } // async Task - ok
-		async Task T3() { await Stuff().ConfigureAwait(true); } // async Task - ok
+		async Task T3() { await Stuff().ConfigureAwait(true); }
 	}
 
 	public static async Task ATMethodAsync2()
 	{
 		async void V1() { await Stuff(); }
 		async void V2() { await Stuff().ConfigureAwait(false); } // async void - not ok
-		async void V3() { await Stuff().ConfigureAwait(true); } // async void - not ok
+		async void V3() { await Stuff().ConfigureAwait(true); }
 
 		async Task T1() { await Stuff(); }
 		async Task T2() { await Stuff().ConfigureAwait(false); } // async Task - ok
-		async Task T3() { await Stuff().ConfigureAwait(true); } // async Task - ok
+		async Task T3() { await Stuff().ConfigureAwait(true); }
 	}
 
 	static Task Stuff()

--- a/WTG.Analyzers/Analyzers/Async/AsyncAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Async/AsyncAnalyzer.cs
@@ -26,7 +26,8 @@ namespace WTG.Analyzers
 			var invoke = (InvocationExpressionSyntax)context.Node;
 
 			if (invoke.Expression is MemberAccessExpressionSyntax member &&
-			member.Name.Identifier.Text == nameof(Task.ConfigureAwait) && // quick check before hitting the SemanticModel.
+				member.Name.Identifier.Text == nameof(Task.ConfigureAwait) && // quick check before hitting the SemanticModel.
+				!HasLiteralTrueArgument(invoke) &&
 				IsConfigureAwait(context.SemanticModel, invoke) &&
 				IsWithinAsyncVoidMethod(context.SemanticModel, invoke))
 			{
@@ -66,6 +67,14 @@ namespace WTG.Analyzers
 		{
 			var symbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invoke).Symbol;
 			return symbol != null && symbol.IsMatch("System.Threading.Tasks.Task", nameof(Task.ConfigureAwait));
+		}
+
+		static bool HasLiteralTrueArgument(InvocationExpressionSyntax invoke)
+		{
+			var arguments = invoke.ArgumentList.Arguments;
+
+			return arguments.Count == 1
+				&& arguments[0].Expression.IsKind(SyntaxKind.TrueLiteralExpression);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #51 

Passing a literal true into `ConfigureAwait` is now considered 'ok', all other values will continue to trip the WTG2001 warning when called from within an `async void` method.