### PR TITLE
Nameof language version

### DIFF
--- a/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -45,7 +45,7 @@ namespace WTG.Analyzers.Test
 		public async Task NoErrorOnEmptyInput()
 		{
 			var analyzer = new TAnalyzer();
-			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, string.Empty).ConfigureAwait(false);
+			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, ModelUtils.CreateDocument(string.Empty)).ConfigureAwait(false);
 			Assert.That(diagnostics, IsDiagnostic.Empty);
 		}
 
@@ -62,25 +62,27 @@ namespace WTG.Analyzers.Test
 		{
 			var filter = CreateFilter(data);
 			var analyzer = new TAnalyzer();
-			var actual = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, data.Source).ConfigureAwait(false);
+			var document = ModelUtils.CreateDocument(data);
+			var actual = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, document).ConfigureAwait(false);
 
 			Assert.That(actual.Where(filter), IsDiagnostic.EqualTo(data.Diagnostics));
 
 			var fixer = new CodeFixer(analyzer, new TCodeFix());
 			fixer.DiagnosticFilter = filter;
 
-			await fixer.VerifyFixAsync(data.Source, data.Result).ConfigureAwait(false);
+			await fixer.VerifyFixAsync(document, data.Result).ConfigureAwait(false);
 		}
 
 		[Test]
 		public async Task BulkUpdate([ValueSource(nameof(Samples))] SampleDataSet data)
 		{
 			var analyzer = new TAnalyzer();
-			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, data.Source).ConfigureAwait(false);
+			var document = ModelUtils.CreateDocument(data);
+			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, document).ConfigureAwait(false);
 
 			var fixer = new CodeFixer(analyzer, new TCodeFix());
 			fixer.DiagnosticFilter = CreateFilter(data);
-			await fixer.VerifyBulkFixAsync(data.Source, data.Result).ConfigureAwait(false);
+			await fixer.VerifyBulkFixAsync(document, data.Result).ConfigureAwait(false);
 		}
 
 		#region Implementation

--- a/WTG.Analyzers.Test/AnalyzerOnlyTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerOnlyTest.cs
@@ -21,7 +21,7 @@ namespace WTG.Analyzers.Test
 		public async Task NoErrorOnEmptyInput()
 		{
 			var analyzer = new TAnalyzer();
-			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, string.Empty).ConfigureAwait(false);
+			var diagnostics = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, ModelUtils.CreateDocument(string.Empty)).ConfigureAwait(false);
 			Assert.That(diagnostics, IsDiagnostic.Empty);
 		}
 
@@ -30,7 +30,7 @@ namespace WTG.Analyzers.Test
 		{
 			var filter = CreateFilter(data);
 			var analyzer = new TAnalyzer();
-			var actual = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, data.Source).ConfigureAwait(false);
+			var actual = await DiagnosticUtils.GetDiagnosticsAsync(analyzer, ModelUtils.CreateDocument(data)).ConfigureAwait(false);
 
 			Assert.That(actual.Where(filter), IsDiagnostic.EqualTo(data.Diagnostics));
 		}

--- a/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>CSharp5</languageVersion>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Diagnostics.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics>
-	<languageVersion>CSharp5</languageVersion>
+	<languageVersion>5</languageVersion>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Source.cs
+++ b/WTG.Analyzers.Test/TestData/ToStringAnalyzer/Enum/OldLanguageVersion/Source.cs
@@ -1,0 +1,17 @@
+using System;
+
+public static class Foo
+{
+	public static string Method()
+	{
+		return Flags.Value1.ToString();
+	}
+}
+
+[Flags]
+public enum Flags
+{
+	None = 0,
+	Value1 = 1,
+	Value2 = 2,
+}

--- a/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreStackallocSpan/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreStackallocSpan/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>CSharp7_3</languageVersion>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreStackallocSpan/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreStackallocSpan/Diagnostics.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics>
-	<languageVersion>CSharp7_3</languageVersion>
+	<languageVersion>7.3</languageVersion>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreTargetTypedDefault/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreTargetTypedDefault/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>CSharp7_3</languageVersion>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreTargetTypedDefault/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VarAnalyzer/IgnoreTargetTypedDefault/Diagnostics.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics>
-	<languageVersion>CSharp7_3</languageVersion>
+	<languageVersion>7.3</languageVersion>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default." severity="Hidden">
 	<suppressId>CS0107</suppressId>
-	<languageVersion>CSharp7_3</languageVersion>
+	<languageVersion>7.3</languageVersion>
 	<diagnostic>
 		<location>Test0.cs: (29,2-9)</location>
 	</diagnostic>

--- a/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/DetectAndFix/Diagnostics.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default." severity="Hidden">
 	<suppressId>CS0107</suppressId>
+	<languageVersion>CSharp7_3</languageVersion>
 	<diagnostic>
 		<location>Test0.cs: (29,2-9)</location>
 	</diagnostic>

--- a/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
+++ b/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
@@ -12,6 +12,11 @@
     <EmbeddedResource Include="TestData\**\*.xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="TestData\ToStringAnalyzer\Enum\OldLanguageVersion\Diagnostics.xml" />
+    <None Remove="TestData\VarAnalyzer\IgnoreStackallocSpan\Diagnostics.xml" />
+    <None Remove="TestData\VarAnalyzer\IgnoreTargetTypedDefault\Diagnostics.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\WTG.Analyzers.TestFramework\WTG.Analyzers.TestFramework.csproj" />
     <ProjectReference Include="..\WTG.Analyzers.Utils\WTG.Analyzers.Utils.csproj" />
     <ProjectReference Include="..\WTG.Analyzers\WTG.Analyzers.csproj" />

--- a/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
+++ b/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
@@ -12,11 +12,6 @@
     <EmbeddedResource Include="TestData\**\*.xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="TestData\ToStringAnalyzer\Enum\OldLanguageVersion\Diagnostics.xml" />
-    <None Remove="TestData\VarAnalyzer\IgnoreStackallocSpan\Diagnostics.xml" />
-    <None Remove="TestData\VarAnalyzer\IgnoreTargetTypedDefault\Diagnostics.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\WTG.Analyzers.TestFramework\WTG.Analyzers.TestFramework.csproj" />
     <ProjectReference Include="..\WTG.Analyzers.Utils\WTG.Analyzers.Utils.csproj" />
     <ProjectReference Include="..\WTG.Analyzers\WTG.Analyzers.csproj" />

--- a/WTG.Analyzers.TestFramework.Test/CodeFixerTest.cs
+++ b/WTG.Analyzers.TestFramework.Test/CodeFixerTest.cs
@@ -24,13 +24,14 @@ namespace WTG.Analyzers.Framework.Test
 
 			var fixer = new CodeFixer(analyzerMock, fixProviderMock);
 			await fixer.VerifyFixAsync(
+				ModelUtils.CreateDocument(
 				@"using System;
 				namespace MyNamespace
 				{
 					public class MyClass1 { }
 					public class MyClass2 { }
 					public class MyClass3 { }
-				}",
+				}"),
 				@"using System;
 				namespace MyNamespace
 				{

--- a/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
@@ -25,11 +25,6 @@ namespace WTG.Analyzers.TestFramework
 		public CodeFixProvider CodeFixProvider { get; }
 		public Func<Diagnostic, bool> DiagnosticFilter { get; set; }
 
-		public Task VerifyFixAsync(string oldSource, string newSource)
-		{
-			return VerifyFixAsync(ModelUtils.CreateDocument(oldSource), newSource);
-		}
-
 		public async Task VerifyFixAsync(Document document, string newSource)
 		{
 			document = await FixDocumentAsync(document).ConfigureAwait(false);
@@ -37,9 +32,8 @@ namespace WTG.Analyzers.TestFramework
 			Assert.That(actual, Is.EqualTo(newSource));
 		}
 
-		public async Task VerifyBulkFixAsync(string oldSource, string newSource)
+		public async Task VerifyBulkFixAsync(Document document, string newSource)
 		{
-			var document = ModelUtils.CreateDocument(oldSource);
 			document = await BulkFixDocumentAsync(document).ConfigureAwait(false);
 			var actual = await GetReducedStringFromDocumentAsync(document).ConfigureAwait(false);
 			Assert.That(actual, Is.EqualTo(newSource));

--- a/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
@@ -9,11 +9,6 @@ namespace WTG.Analyzers.TestFramework
 {
 	public static partial class DiagnosticUtils
 	{
-		public static async Task<Diagnostic[]> GetDiagnosticsAsync(DiagnosticAnalyzer analyzer, params string[] sources)
-		{
-			return await GetDiagnosticsAsync(analyzer, ModelUtils.GetDocuments(sources)).ConfigureAwait(false);
-		}
-
 		public static async Task<Diagnostic[]> GetDiagnosticsAsync(DiagnosticAnalyzer analyzer, params Document[] documents)
 		{
 			var ids = new HashSet<string>(analyzer.SupportedDiagnostics.Select(x => x.Id));

--- a/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -13,12 +13,23 @@ namespace WTG.Analyzers.TestFramework
 {
 	public static class ModelUtils
 	{
+		public static Document CreateDocument(SampleDataSet dataSet)
+		{
+			var document = CreateDocument(dataSet.Source);
+			var project = document.Project;
+
+			project = project.WithParseOptions(
+				((CSharpParseOptions)project.ParseOptions).WithLanguageVersion(dataSet.LanguageVersion));
+
+			return project.GetDocument(document.Id);
+		}
+
 		public static Document CreateDocument(string source)
 		{
 			return CreateProject(new[] { source }).Documents.First();
 		}
 
-		public static Document[] GetDocuments(string[] sources)
+		public static Document[] CreateDocument(params string[] sources)
 		{
 			var project = CreateProject(sources);
 			var documents = project.Documents.ToArray();
@@ -68,10 +79,6 @@ namespace WTG.Analyzers.TestFramework
 				.WithAllowUnsafe(enabled: true)
 				.WithOutputKind(OutputKind.DynamicallyLinkedLibrary);
 			project = project.WithCompilationOptions(compilationOptions);
-
-			var parseOptions = (CSharpParseOptions)project.ParseOptions;
-			parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.CSharp7_3);
-			project = project.WithParseOptions(parseOptions);
 
 			solution = project.Solution;
 

--- a/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
+++ b/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
@@ -121,7 +121,7 @@ namespace WTG.Analyzers.TestFramework
 
 				var languageVersionStr = root.Element("languageVersion")?.Value;
 
-				if (languageVersionStr != null && Enum.TryParse<LanguageVersion>(languageVersionStr, out var tmp))
+				if (LanguageVersionFacts.TryParse(languageVersionStr, out var tmp))
 				{
 					languageVersion = tmp;
 				}

--- a/WTG.Analyzers/Analyzers/ToString/ToStringAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/ToString/ToStringAnalyzer.cs
@@ -39,6 +39,7 @@ namespace WTG.Analyzers
 			}
 
 			var invoke = (InvocationExpressionSyntax)context.Node;
+			var supportsNameof = SupportsNameof(context.SemanticModel.SyntaxTree);
 
 			switch (invoke.Expression.Kind())
 			{
@@ -59,7 +60,8 @@ namespace WTG.Analyzers
 										break;
 
 									case SpecialType.System_Enum:
-										if (symbol.Parameters.Length == 0 &&
+										if (supportsNameof &&
+											symbol.Parameters.Length == 0 &&
 											IsEnumLiteral(member.Expression, context.SemanticModel, context.CancellationToken))
 										{
 											context.ReportDiagnostic(Rules.CreatePreferNameofOverCallingToStringOnAnEnumDiagnostic(invoke.GetLocation()));
@@ -87,6 +89,13 @@ namespace WTG.Analyzers
 					}
 					break;
 			}
+		}
+
+		static bool SupportsNameof(SyntaxTree syntaxTree)
+		{
+			var languageVersion = ((CSharpParseOptions)syntaxTree.Options).LanguageVersion;
+
+			return languageVersion == LanguageVersion.Default || languageVersion > LanguageVersion.CSharp5;
 		}
 
 		static bool IsEnumLiteral(ExpressionSyntax expression, SemanticModel model, CancellationToken cancellationToken)

--- a/WTG.Analyzers/Analyzers/ToString/ToStringAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/ToString/ToStringAnalyzer.cs
@@ -95,7 +95,7 @@ namespace WTG.Analyzers
 		{
 			var languageVersion = ((CSharpParseOptions)syntaxTree.Options).LanguageVersion;
 
-			return languageVersion == LanguageVersion.Default || languageVersion > LanguageVersion.CSharp5;
+			return languageVersion >= LanguageVersion.CSharp6;
 		}
 
 		static bool IsEnumLiteral(ExpressionSyntax expression, SemanticModel model, CancellationToken cancellationToken)


### PR DESCRIPTION
Check the language version on the `SyntaxTree.Options` to see if `nameof` is even supported before suggesting we use it.