### PR TITLE
Remove additional Code Contracts bits and bobs

### DIFF
--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Diagnostics.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG2004" message="This project does not use Code Contracts." severity="Warning">
+	<diagnostic>
+		<location>Test0.cs: (10,4-33)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (11,4-58)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Result.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Result.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace TestAssembly
+{
+	public class PedanticForAll
+	{
+		public static string ToCsvLineOrSomething(IEnumerable<string> s)
+		{
+			if (s == null)
+			{
+				throw new System.ArgumentNullException(nameof(s));
+			}
+
+			return string.Join(",", s);
+		}
+	}
+}

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Source.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/Requires/ForAll/Source.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+
+namespace TestAssembly
+{
+	public class PedanticForAll
+	{
+		public static string ToCsvLineOrSomething(IEnumerable<string> s)
+		{
+			Contract.Requires(s != null);
+			Contract.Requires(Contract.ForAll(s, x => x != null));
+			return string.Join(",", s);
+		}
+	}
+}

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Diagnostics.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG2004" message="This project does not use Code Contracts." severity="Warning">
+	<diagnostic>
+		<location>Test0.cs: (4,1-126)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (10,3-78)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (13,3-118)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Result.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Result.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace TestAssembly
+{
+	class CodeAnalysisSuppression
+	{
+		public bool Foo(DateTime x) => x.DayOfWeek == DayOfWeek.Sunday;
+
+
+		public bool Bar(DateTime x) => x.Day != 2;
+	}
+}

--- a/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/CodeContractsAnalyzer/SuppressMessage/Source.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Contracts", "Requires-31-375", Target = "Foo.Bar.Baz")]
+
+namespace TestAssembly
+{
+	class CodeAnalysisSuppression
+	{
+		[SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+		public bool Foo(DateTime x) => x.DayOfWeek == DayOfWeek.Sunday;
+
+		[SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Dummy justification.")]
+		public bool Bar(DateTime x) => x.Day != 2;
+	}
+}

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsCodeFixProvider.cs
@@ -81,6 +81,10 @@ namespace WTG.Analyzers
 						CreateReplaceWithIfAction(c => FixRequires(document, diagnostic, supplementalLocation, "Value cannot be null or empty.", c)),
 						diagnostic);
 				}
+				else if (CodeContractsHelper.InvokesContractForAll(semanticModel, invoke, CancellationToken.None))
+				{
+					context.RegisterCodeFix(CreateDeleteAction(context.Document, diagnostic), diagnostic);
+				}
 				else if (CodeContractsHelper.AccessesParameter(semanticModel, invoke, out supplementalLocation, context.CancellationToken))
 				{
 					context.RegisterCodeFix(

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsFixAllProvider.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsFixAllProvider.cs
@@ -68,6 +68,10 @@ namespace WTG.Analyzers
 						{
 							modified = CodeContractsHelper.ConvertRequires(invoke, location, "Value cannot be null or empty.");
 						}
+						else if (CodeContractsHelper.InvokesContractForAll(semanticModel, invoke, CancellationToken.None))
+						{
+							return modified.WithAdditionalAnnotations(DeleteMEAnnotation);
+						}
 						else if (CodeContractsHelper.AccessesParameter(semanticModel, invoke, out location, cancellationToken))
 						{
 							modified = CodeContractsHelper.ConvertRequires(invoke, location, "Invalid Argument.");

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
@@ -285,6 +285,25 @@ namespace WTG.Analyzers
 					: ExpressionSyntaxFactory.CreateLiteral(defaultMessage));
 		}
 
+		public static bool IsCodeContractsSuppression(SemanticModel semanticModel, AttributeSyntax attribute)
+		{
+			var attributeArguments = attribute.ArgumentList?.Arguments;
+
+			if (attributeArguments == null || attributeArguments.Value.Count == 0)
+			{
+				return false;
+			}
+
+			var firstArgument = attributeArguments.Value[0];
+			if (!firstArgument.Expression.IsKind(SyntaxKind.StringLiteralExpression))
+			{
+				return false;
+			}
+
+			var literal = semanticModel.GetConstantValue(firstArgument.Expression);
+			return literal.HasValue && literal.Value is string literalValue && literalValue == "Microsoft.Contracts";
+		}
+
 		public static SyntaxNode WithElasticTriviaFrom(SyntaxNode target, SyntaxNode source)
 		{
 			return target

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsUsingSimplifier.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsUsingSimplifier.cs
@@ -23,7 +23,7 @@ namespace WTG.Analyzers
 
 		public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
 		{
-			if (!node.HasAnnotation(Simplifier.Annotation) && node.Name.IsMatch("System.Diagnostics.Contracts"))
+			if (!node.HasAnnotation(Simplifier.Annotation) && (node.Name.IsMatch("System.Diagnostics.Contracts") || node.Name.IsMatch("System.Diagnostics.CodeAnalysis")))
 			{
 				return node.WithAdditionalAnnotations(Simplifier.Annotation);
 			}


### PR DESCRIPTION
- Remove `SuppressMessage("Microsoft.Contracts", ...)`
- Remove preconditions that invoke `Contract.ForAll`

This synchronizes the rule with our dedicated internal tool. I've added equivalent unit tests to the internal tool's tests.

Resolves #77.