### PR TITLE
Update packages

### DIFF
--- a/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -113,7 +113,7 @@ namespace WTG.Analyzers.TestFramework
 				typeof(object),
 				typeof(Enumerable),
 				typeof(CSharpCompilation),
-				typeof(Compilation)
+				typeof(Compilation),
 			};
 
 			var wellKnownAssemblyNames = new[]
@@ -124,7 +124,7 @@ namespace WTG.Analyzers.TestFramework
 				"System.Console",
 				"System.Linq.Expressions",
 				"System.Linq.Queryable",
-				"System.Runtime"
+				"System.Runtime",
 			};
 
 			var builder = ImmutableArray.CreateBuilder<MetadataReference>(initialCapacity: types.Length + wellKnownAssemblyNames.Length);

--- a/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -54,7 +54,9 @@ namespace WTG.Analyzers.TestFramework
 
 		public static Project CreateProject(params string[] sources)
 		{
+#pragma warning disable CA2000 // Dispose objects before losing scope
 			return AddProject(CreateWorkspace().CurrentSolution, TestProjectName, sources);
+#pragma warning restore CA2000 // Dispose objects before losing scope
 		}
 
 		public static Project AddAdHocDependency(this Project project, string assemblyName, params string[] sources)

--- a/WTG.Analyzers.Utils.Test/SyntaxTreeExtensionsTest.cs
+++ b/WTG.Analyzers.Utils.Test/SyntaxTreeExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
@@ -31,14 +31,16 @@ namespace WTG.Analyzers.Utils.Test
 
 		static async Task<bool> Check(string filename, string content)
 		{
-			var document =
-				new AdhocWorkspace()
-				.CurrentSolution
-				.AddProject("Barry", "Barry", LanguageNames.CSharp)
-				.AddDocument(filename, SourceText.From(content));
+			using (var workspace = new AdhocWorkspace())
+			{
+				var document = workspace
+					.CurrentSolution
+					.AddProject("Barry", "Barry", LanguageNames.CSharp)
+					.AddDocument(filename, SourceText.From(content));
 
-			var tree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
-			return tree.IsGenerated(default(CancellationToken));
+				var tree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
+				return tree.IsGenerated(default(CancellationToken));
+			}
 		}
 
 		#endregion

--- a/WTG.Analyzers.Utils/paket.references
+++ b/WTG.Analyzers.Utils/paket.references
@@ -1,4 +1,5 @@
-Microsoft.CodeAnalysis.CSharp.Workspaces
+group Roslyn
+	Microsoft.CodeAnalysis.CSharp.Workspaces
 
 group Analyzers
 	StyleCop.Analyzers

--- a/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
+++ b/WTG.Analyzers/Analyzers/CodeContracts/CodeContractsHelper.cs
@@ -262,7 +262,7 @@ namespace WTG.Analyzers
 				argumentList = SyntaxFactory.ArgumentList(
 					SyntaxFactory.SeparatedList(new[]
 					{
-						SyntaxFactory.Argument(ExpressionSyntaxFactory.CreateNameof(paramSyntax))
+						SyntaxFactory.Argument(ExpressionSyntaxFactory.CreateNameof(paramSyntax)),
 					}));
 			}
 

--- a/WTG.Analyzers/Analyzers/Usings/UsingDirectiveKind.cs
+++ b/WTG.Analyzers/Analyzers/Usings/UsingDirectiveKind.cs
@@ -1,9 +1,9 @@
-﻿namespace WTG.Analyzers
+namespace WTG.Analyzers
 {
 	public enum UsingDirectiveKind
 	{
 		Regular,
 		Static,
-		Alias
+		Alias,
 	}
 }

--- a/WTG.Analyzers/paket.references
+++ b/WTG.Analyzers/paket.references
@@ -1,4 +1,5 @@
-Microsoft.CodeAnalysis.CSharp.Workspaces
+group Roslyn
+	Microsoft.CodeAnalysis.CSharp.Workspaces
 
 group Analyzers
 	StyleCop.Analyzers

--- a/build/CodeAnalysis.ruleset
+++ b/build/CodeAnalysis.ruleset
@@ -8,4 +8,10 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1062" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="None" />
+  </Rules>
 </RuleSet>

--- a/build/CodeAnalysis.ruleset
+++ b/build/CodeAnalysis.ruleset
@@ -1,9 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Production Assembly Rules" ToolsVersion="15.0">
-	<Include Path="StyleCopAnalyzers.ruleset" Action="Default" />
-
-	<Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-		<Rule Id="IDE0016" Action="None" />
-		<Rule Id="IDE0016WithoutSuggestion" Action="None" />
-	</Rules>
+  <Include Path="StyleCopAnalyzers.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0016" Action="None" />
+    <Rule Id="IDE0016WithoutSuggestion" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
+  </Rules>
 </RuleSet>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,4 @@
 version 5.176.3
-strategy: min
 
 # All packages come from the public NuGet Gallery
 source https://api.nuget.org/v3/index.json
@@ -14,15 +13,22 @@ source https://api.nuget.org/v3/index.json
 #
 
 nuget NuGet.CommandLine
-nuget Microsoft.CodeAnalysis 2.0
+
+group Roslyn
+	source https://api.nuget.org/v3/index.json
+	storage: none
+	strategy: min
+	nuget Microsoft.CodeAnalysis 2.0
 
 group Analyzers
 	source https://api.nuget.org/v3/index.json
+	storage: none
 	nuget StyleCop.Analyzers
 	nuget Microsoft.CodeAnalysis.FxCopAnalyzers
 
 group Test
 	source https://api.nuget.org/v3/index.json
+	storage: none
 	nuget Appveyor.TestLogger
 	nuget Microsoft.CodeAnalysis 2.8
 	nuget Microsoft.Composition >= 1.0.31

--- a/paket.lock
+++ b/paket.lock
@@ -6,16 +6,16 @@ GROUP Analyzers
 STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Microsoft.CodeAnalysis.FxCopAnalyzers (2.6.2)
-      Microsoft.CodeQuality.Analyzers (2.6.2)
-      Microsoft.NetCore.Analyzers (2.6.2)
-      Microsoft.NetFramework.Analyzers (2.6.2)
-      Text.Analyzers (2.6.2)
-    Microsoft.CodeQuality.Analyzers (2.6.2)
-    Microsoft.NetCore.Analyzers (2.6.2)
-    Microsoft.NetFramework.Analyzers (2.6.2)
+    Microsoft.CodeAnalysis.FxCopAnalyzers (2.9.8)
+      Microsoft.CodeAnalysis.VersionCheckAnalyzer (2.9.8)
+      Microsoft.CodeQuality.Analyzers (2.9.8)
+      Microsoft.NetCore.Analyzers (2.9.8)
+      Microsoft.NetFramework.Analyzers (2.9.8)
+    Microsoft.CodeAnalysis.VersionCheckAnalyzer (2.9.8)
+    Microsoft.CodeQuality.Analyzers (2.9.8)
+    Microsoft.NetCore.Analyzers (2.9.8)
+    Microsoft.NetFramework.Analyzers (2.9.8)
     StyleCop.Analyzers (1.1.118)
-    Text.Analyzers (2.6.2)
 
 GROUP Roslyn
 STORAGE: NONE

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,24 @@
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    NuGet.CommandLine (4.9.2)
+
+GROUP Analyzers
+STORAGE: NONE
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    Microsoft.CodeAnalysis.FxCopAnalyzers (2.6.2)
+      Microsoft.CodeQuality.Analyzers (2.6.2)
+      Microsoft.NetCore.Analyzers (2.6.2)
+      Microsoft.NetFramework.Analyzers (2.6.2)
+      Text.Analyzers (2.6.2)
+    Microsoft.CodeQuality.Analyzers (2.6.2)
+    Microsoft.NetCore.Analyzers (2.6.2)
+    Microsoft.NetFramework.Analyzers (2.6.2)
+    StyleCop.Analyzers (1.0.2)
+    Text.Analyzers (2.6.2)
+
+GROUP Roslyn
+STORAGE: NONE
 STRATEGY: MIN
 NUGET
   remote: https://api.nuget.org/v3/index.json
@@ -70,7 +91,6 @@ NUGET
     Microsoft.Composition (1.0.27) - restriction: >= netstandard1.3
     Microsoft.NETCore.Platforms (1.1) - restriction: || (&& (>= dnxcore50) (>= netstandard1.3)) (&& (>= dnxcore50) (>= netstandard1.6)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     Microsoft.NETCore.Targets (1.1) - restriction: || (&& (>= dnxcore50) (>= netstandard1.3)) (&& (>= dnxcore50) (>= netstandard1.6)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    NuGet.CommandLine (4.9.2)
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -566,21 +586,8 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.XPath (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
 
-GROUP Analyzers
-NUGET
-  remote: https://api.nuget.org/v3/index.json
-    Microsoft.CodeAnalysis.FxCopAnalyzers (2.6.2)
-      Microsoft.CodeQuality.Analyzers (2.6.2)
-      Microsoft.NetCore.Analyzers (2.6.2)
-      Microsoft.NetFramework.Analyzers (2.6.2)
-      Text.Analyzers (2.6.2)
-    Microsoft.CodeQuality.Analyzers (2.6.2)
-    Microsoft.NetCore.Analyzers (2.6.2)
-    Microsoft.NetFramework.Analyzers (2.6.2)
-    StyleCop.Analyzers (1.0.2)
-    Text.Analyzers (2.6.2)
-
 GROUP Test
+STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Appveyor.TestLogger (2.0)

--- a/paket.lock
+++ b/paket.lock
@@ -14,7 +14,7 @@ NUGET
     Microsoft.CodeQuality.Analyzers (2.6.2)
     Microsoft.NetCore.Analyzers (2.6.2)
     Microsoft.NetFramework.Analyzers (2.6.2)
-    StyleCop.Analyzers (1.0.2)
+    StyleCop.Analyzers (1.1.118)
     Text.Analyzers (2.6.2)
 
 GROUP Roslyn


### PR DESCRIPTION
* Update StyleCop and FxCop analyzers.
* All packages other than `NuGet.CommandLine` should be in a group that uses `storage:none`