### PR TITLE
Added Emit overload usage analyzer.

### DIFF
--- a/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -30,6 +30,7 @@ namespace WTG.Analyzers.Test
 	[TestFixture(TypeArgs = new[] { typeof(CodeContractsAnalyzer), typeof(CodeContractsCodeFixProvider) })]
 	[TestFixture(TypeArgs = new[] { typeof(DiscardThrowAnalyzer), typeof(DiscardThrowCodeFixProvider) })]
 	[TestFixture(TypeArgs = new[] { typeof(AwaitCompletedAnalyzer), typeof(AwaitCompletedCodeFixProvider) })]
+	[TestFixture(TypeArgs = new[] { typeof(EmitAnalyzer), typeof(EmitCodeFixProvider) })]
 	public class AnalyzerAndCodeFixTest<TAnalyzer, TCodeFix>
 		where TAnalyzer : DiagnosticAnalyzer, new()
 		where TCodeFix : CodeFixProvider, new()

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Diagnostics.xml
@@ -1,0 +1,5 @@
+<diagnostics id="WTG2005" severity="Warning">
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (8, 3-32)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Result.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Result.cs
@@ -1,0 +1,10 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I4, 2 + 3);
+		g.Emit(OpCodes.Ldc_I8, (long)(2 + 3));
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/ComplexConversion/Source.cs
@@ -1,0 +1,10 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I4, 2 + 3);
+		g.Emit(OpCodes.Ldc_I8, 2 + 3);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/CorrectOverloads.Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/CorrectOverloads.Source.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Constants(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldarg_0);
+		g.Emit(OpCodes.Ldarg_S, (byte)8);
+		g.Emit(OpCodes.Ldarg, (short)0);
+
+		g.Emit(OpCodes.Ldc_I4_S, (sbyte)8);
+		g.Emit(OpCodes.Ldc_I4, 8);
+		g.Emit(OpCodes.Ldc_I8, 8L);
+		g.Emit(OpCodes.Ldc_R4, 8f);
+		g.Emit(OpCodes.Ldc_R8, 8d);
+	}
+
+	public void Labels(ILGenerator g)
+	{
+		g.Emit(OpCodes.Switch, new Label[] { g.DefineLabel(), g.DefineLabel() });
+		g.Emit(OpCodes.Br, g.DefineLabel());
+		g.Emit(OpCodes.Br_S, g.DefineLabel());
+	}
+
+	public void Locals(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldloc, (short)0);
+		g.Emit(OpCodes.Ldloc_S, (byte)0);
+		g.Emit(OpCodes.Stloc, g.DeclareLocal(typeof(int)));
+		g.Emit(OpCodes.Stloc_S, g.DeclareLocal(typeof(int)));
+	}
+
+	public void MethodInfo(ILGenerator g, MethodInfo info)
+	{
+		g.Emit(OpCodes.Call, info);
+		g.Emit(OpCodes.Callvirt, info);
+		g.Emit(OpCodes.Jmp, info);
+		g.EmitCall(OpCodes.Call, info, Type.EmptyTypes);
+		g.EmitCall(OpCodes.Callvirt, info, Type.EmptyTypes);
+	}
+
+	public void ConstructorInfo(ILGenerator g, ConstructorInfo info)
+	{
+		g.Emit(OpCodes.Call, info); // needed for an emitted constructor to call the base constructor.
+		g.Emit(OpCodes.Newobj, info);
+	}
+
+	public void FieldInfo(ILGenerator g, FieldInfo info)
+	{
+		g.Emit(OpCodes.Ldfld, info);
+		g.Emit(OpCodes.Stfld, info);
+		g.Emit(OpCodes.Ldflda, info);
+	}
+
+	public void Signature(ILGenerator g, SignatureHelper sig)
+	{
+		g.Emit(OpCodes.Calli, sig);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Diagnostics.xml
@@ -1,0 +1,44 @@
+<diagnostics id="WTG2005" severity="Warning">
+	<diagnostic message="The Ldarg_0 opcode does not take an argument.">
+		<location>Test0.cs: (7, 3-29)</location>
+	</diagnostic>
+	<diagnostic message="The Ldarg_S opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (8, 3-29)</location>
+	</diagnostic>
+	<diagnostic message="The Ldarg opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (9, 3-27)</location>
+	</diagnostic>
+
+	<diagnostic message="The Ldc_I4_S opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (11, 3-30)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (12, 3-28)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (13, 3-28)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (14, 3-28)</location>
+	</diagnostic>
+
+	<diagnostic message="The Ldarg_S opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (19, 3-33)</location>
+	</diagnostic>
+	<diagnostic message="The Ldarg opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (20, 3-31)</location>
+	</diagnostic>
+
+	<diagnostic message="The Ldc_I4_S opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (22, 3-34)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (23, 3-32)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (24, 3-32)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (25, 3-32)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Result.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Result.cs
@@ -1,0 +1,27 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Literal(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldarg_0);
+		g.Emit(OpCodes.Ldarg_S, (byte)8);
+		g.Emit(OpCodes.Ldarg, (short)0);
+
+		g.Emit(OpCodes.Ldc_I4_S, (sbyte)8);
+		g.Emit(OpCodes.Ldc_I8, 8L);
+		g.Emit(OpCodes.Ldc_R4, 8f);
+		g.Emit(OpCodes.Ldc_R8, 8d);
+	}
+
+	public void Variable(ILGenerator g, int value)
+	{
+		g.Emit(OpCodes.Ldarg_S, (byte)value);
+		g.Emit(OpCodes.Ldarg, (short)value);
+
+		g.Emit(OpCodes.Ldc_I4_S, (sbyte)value);
+		g.Emit(OpCodes.Ldc_I8, (long)value);
+		g.Emit(OpCodes.Ldc_R4, (float)value);
+		g.Emit(OpCodes.Ldc_R8, (double)value);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Fixable/Source.cs
@@ -1,0 +1,27 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Literal(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldarg_0, 0);
+		g.Emit(OpCodes.Ldarg_S, 8);
+		g.Emit(OpCodes.Ldarg, 0);
+
+		g.Emit(OpCodes.Ldc_I4_S, 8);
+		g.Emit(OpCodes.Ldc_I8, 8);
+		g.Emit(OpCodes.Ldc_R4, 8);
+		g.Emit(OpCodes.Ldc_R8, 8);
+	}
+
+	public void Variable(ILGenerator g, int value)
+	{
+		g.Emit(OpCodes.Ldarg_S, value);
+		g.Emit(OpCodes.Ldarg, value);
+
+		g.Emit(OpCodes.Ldc_I4_S, value);
+		g.Emit(OpCodes.Ldc_I8, value);
+		g.Emit(OpCodes.Ldc_R4, value);
+		g.Emit(OpCodes.Ldc_R8, value);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Diagnostics.xml
@@ -1,0 +1,14 @@
+<diagnostics id="WTG2005" severity="Warning">
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (7, 3-31)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (8, 3-31)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (9, 3-32)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (10, 3-32)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Result.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Result.cs
@@ -1,0 +1,12 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I8, 16L);
+		g.Emit(OpCodes.Ldc_I8, 2L);
+		g.Emit(OpCodes.Ldc_I4, 16);
+		g.Emit(OpCodes.Ldc_I4, 2);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/NonStandardFormat/Source.cs
@@ -1,0 +1,12 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I8, 0x10);
+		g.Emit(OpCodes.Ldc_I8, 0b10);
+		g.Emit(OpCodes.Ldc_I4, 0x10L);
+		g.Emit(OpCodes.Ldc_I4, 0b10L);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/NotFixable/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/NotFixable/Diagnostics.xml
@@ -1,0 +1,14 @@
+<diagnostics id="WTG2005" severity="Warning">
+	<diagnostic message="The Ldarg_S opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (8, 3-32)</location>
+	</diagnostic>
+	<diagnostic message="The Newarr opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (9, 3-31)</location>
+	</diagnostic>
+	<diagnostic message="The Ldloc opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (10, 3-30)</location>
+	</diagnostic>
+	<diagnostic message="The Calli opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (11, 3-30)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/NotFixable/Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/NotFixable/Source.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g, MethodInfo info)
+	{
+		g.Emit(OpCodes.Ldarg_S, info);
+		g.Emit(OpCodes.Newarr, info);
+		g.Emit(OpCodes.Ldloc, info);
+		g.Emit(OpCodes.Calli, info);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Diagnostics.xml
@@ -1,0 +1,14 @@
+<diagnostics id="WTG2005" severity="Warning">
+	<diagnostic message="The Ldc_I4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (7, 3-34)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_I8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (8, 3-34)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R4 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (9, 3-34)</location>
+	</diagnostic>
+	<diagnostic message="The Ldc_R8 opcode cannot be used with this emit overload.">
+		<location>Test0.cs: (10, 3-34)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Result.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Result.cs
@@ -1,0 +1,12 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I4, 8);
+		g.Emit(OpCodes.Ldc_I8, 8L);
+		g.Emit(OpCodes.Ldc_R4, 8f);
+		g.Emit(OpCodes.Ldc_R8, 8d);
+	}
+}

--- a/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Source.cs
+++ b/WTG.Analyzers.Test/TestData/EmitAnalyzer/Uncast/Source.cs
@@ -1,0 +1,12 @@
+using System.Reflection.Emit;
+
+class Test
+{
+	public void Method(ILGenerator g)
+	{
+		g.Emit(OpCodes.Ldc_I4, (byte)8);
+		g.Emit(OpCodes.Ldc_I8, (byte)8);
+		g.Emit(OpCodes.Ldc_R4, (byte)8);
+		g.Emit(OpCodes.Ldc_R8, (byte)8);
+	}
+}

--- a/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
+++ b/WTG.Analyzers.Utils.Test/ExpressionSyntaxFactoryTest.cs
@@ -61,6 +61,35 @@ namespace WTG.Analyzers.Utils.Test
 			return ExpressionSyntaxFactory.CreateLiteral(value).ToString();
 		}
 
+		[TestCase(0, ExpectedResult = "0L")]
+		[TestCase(1, ExpectedResult = "1L")]
+		[TestCase(-1, ExpectedResult = "-1L")]
+		[TestCase(65536, ExpectedResult = "65536L")]
+		public string CreateLiteralLong(long value)
+		{
+			return ExpressionSyntaxFactory.CreateLiteral(value).ToString();
+		}
+
+		[TestCase(0, ExpectedResult = "0f")]
+		[TestCase(1, ExpectedResult = "1f")]
+		[TestCase(-1, ExpectedResult = "-1f")]
+		[TestCase(23.1406f, ExpectedResult = "23.1406f")]
+		[TestCase(-23.1406f, ExpectedResult = "-23.1406f")]
+		public string CreateLiteralFloat(float value)
+		{
+			return ExpressionSyntaxFactory.CreateLiteral(value).ToString();
+		}
+
+		[TestCase(0, ExpectedResult = "0d")]
+		[TestCase(1, ExpectedResult = "1d")]
+		[TestCase(-1, ExpectedResult = "-1d")]
+		[TestCase(23.1406d, ExpectedResult = "23.1406d")]
+		[TestCase(-23.1406d, ExpectedResult = "-23.1406d")]
+		public string CreateLiteralDouble(double value)
+		{
+			return ExpressionSyntaxFactory.CreateLiteral(value).ToString();
+		}
+
 		[TestCase(0, ExpectedResult = "1 << 0")]
 		[TestCase(1, ExpectedResult = "1 << 1")]
 		[TestCase(32, ExpectedResult = "1 << 32")]

--- a/WTG.Analyzers.Utils/ExpressionSyntaxFactory.cs
+++ b/WTG.Analyzers.Utils/ExpressionSyntaxFactory.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -97,6 +98,27 @@ namespace WTG.Analyzers.Utils
 			return SyntaxFactory.LiteralExpression(
 				SyntaxKind.StringLiteralExpression,
 				SyntaxFactory.Literal(value));
+		}
+
+		public static LiteralExpressionSyntax CreateLiteral(long value)
+		{
+			return SyntaxFactory.LiteralExpression(
+				SyntaxKind.NumericLiteralExpression,
+				SyntaxFactory.Literal(value.ToString(CultureInfo.InvariantCulture) + "L", value));
+		}
+
+		public static LiteralExpressionSyntax CreateLiteral(float value)
+		{
+			return SyntaxFactory.LiteralExpression(
+				SyntaxKind.NumericLiteralExpression,
+				SyntaxFactory.Literal(value.ToString(CultureInfo.InvariantCulture) + "f", value));
+		}
+
+		public static LiteralExpressionSyntax CreateLiteral(double value)
+		{
+			return SyntaxFactory.LiteralExpression(
+				SyntaxKind.NumericLiteralExpression,
+				SyntaxFactory.Literal(value.ToString(CultureInfo.InvariantCulture) + "d", value));
 		}
 
 		public static InvocationExpressionSyntax CreateNameof(ExpressionSyntax argument)

--- a/WTG.Analyzers/Analyzers/Emit/EmitAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Emit/EmitAnalyzer.cs
@@ -1,0 +1,132 @@
+using System.Collections.Immutable;
+using System.Reflection.Emit;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class EmitAnalyzer : DiagnosticAnalyzer
+	{
+		public const string SuggestedFixProperty = "SuggestedFix";
+		public const string DeleteArgument = "D";
+		public const string ConvertArgument = "C";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+			Rules.UseCorrectEmitOverloadRule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(AnalyzeInvoke, SyntaxKind.InvocationExpression);
+		}
+
+		static void AnalyzeInvoke(SyntaxNodeAnalysisContext context)
+		{
+			var invoke = (InvocationExpressionSyntax)context.Node;
+
+			if (TryIdentifyEmitMethod(context.SemanticModel, invoke, out var actualEmitMethod, context.CancellationToken) &&
+				TryGetOpCodeFieldFromEmitCall(context.SemanticModel, invoke, out var opCodeSymbol, context.CancellationToken) &&
+				EmitMatrix.GetOpCode(opCodeSymbol) is var opcode &&
+				AreCompatible(opcode, actualEmitMethod))
+			{
+				var properties = ImmutableDictionary<string, string>.Empty;
+				DiagnosticDescriptor descriptor;
+
+				var operandType = opcode.GetOperand();
+
+				if (operandType == OpCodeOperand.InlineNone)
+				{
+					descriptor = Rules.UseCorrectEmitOverload_NoneRule;
+					properties = properties.Add(SuggestedFixProperty, DeleteArgument);
+				}
+				else
+				{
+					descriptor = Rules.UseCorrectEmitOverloadRule;
+
+					if (CanConvert(operandType, actualEmitMethod))
+					{
+						properties = properties.Add(SuggestedFixProperty, ConvertArgument);
+					}
+				}
+
+				context.ReportDiagnostic(
+					Diagnostic.Create(
+						descriptor,
+						invoke.GetLocation(),
+						properties,
+						opCodeSymbol.Name));
+			}
+		}
+
+		static bool TryIdentifyEmitMethod(SemanticModel model, InvocationExpressionSyntax invoke, out EmitMethod method, CancellationToken cancellationToken)
+		{
+			var name = ExpressionHelper.GetMethodName(invoke)?.Identifier.Text;
+
+			if (name == nameof(ILGenerator.Emit) || name == nameof(ILGenerator.EmitCall) || name == nameof(ILGenerator.EmitCalli))
+			{
+				var methodSymbol = (IMethodSymbol)model.GetSymbolInfo(invoke, cancellationToken).Symbol;
+
+				if (methodSymbol != null)
+				{
+					return EmitMatrix.TryGetEmitMethod(methodSymbol, out method);
+				}
+			}
+
+			method = EmitMethod.None;
+			return false;
+		}
+
+		static bool TryGetOpCodeFieldFromEmitCall(SemanticModel model, InvocationExpressionSyntax emitCall, out IFieldSymbol opCodeSymbol, CancellationToken cancellation)
+		{
+			if (emitCall.ArgumentList.Arguments[0].Accept(FieldAccessor.Instance) is var fieldIdentifier &&
+				fieldIdentifier != null &&
+				model.GetSymbolInfo(fieldIdentifier, cancellation).Symbol is var fieldSymbol &&
+				fieldSymbol != null &&
+				fieldSymbol.Kind == SymbolKind.Field)
+			{
+				opCodeSymbol = (IFieldSymbol)fieldSymbol;
+				return true;
+			}
+
+			opCodeSymbol = null;
+			return false;
+		}
+
+		static bool AreCompatible(OpCode opcode, EmitMethod emitMethod)
+			=> opcode != OpCode.Invalid && (EmitMatrix.GetSupportedMethods(opcode) & emitMethod) == 0;
+
+		static bool CanConvert(OpCodeOperand requiredOperand, EmitMethod actualMethod)
+		{
+			switch (requiredOperand)
+			{
+				case OpCodeOperand.InlineI:
+				case OpCodeOperand.InlineI8:
+				case OpCodeOperand.InlineR:
+				case OpCodeOperand.InlineVar:
+				case OpCodeOperand.ShortInlineI:
+				case OpCodeOperand.ShortInlineR:
+				case OpCodeOperand.ShortInlineVar:
+					break;
+
+				default:
+					return false;
+			}
+
+			const EmitMethod Mask =
+				EmitMethod.Emit_Byte
+				| EmitMethod.Emit_SByte
+				| EmitMethod.Emit_Int16
+				| EmitMethod.Emit_Int32
+				| EmitMethod.Emit_Int64
+				| EmitMethod.Emit_Single
+				| EmitMethod.Emit_Double;
+
+			return (Mask & actualMethod) != 0;
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Emit/EmitCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Emit/EmitCodeFixProvider.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace WTG.Analyzers
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EmitCodeFixProvider))]
+	public sealed class EmitCodeFixProvider : CodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+			Rules.UseCorrectEmitOverloadDiagnosticID);
+
+		public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public override Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var document = context.Document;
+			var diagnostic = context.Diagnostics.First();
+
+			if (diagnostic.Properties.TryGetValue(EmitAnalyzer.SuggestedFixProperty, out var fixCode))
+			{
+				switch (fixCode)
+				{
+					case EmitAnalyzer.DeleteArgument:
+						context.RegisterCodeFix(
+							CodeAction.Create(
+								"Remove Argument",
+								createChangedDocument: c => RemoveArgumentFixAsync(document, diagnostic, c),
+								equivalenceKey: "RemoveArgument"),
+							diagnostic);
+						break;
+
+					case EmitAnalyzer.ConvertArgument:
+						context.RegisterCodeFix(
+							CodeAction.Create(
+								"Convert Argument",
+								createChangedDocument: c => ConvertArgumentFixAsync(document, diagnostic, c),
+								equivalenceKey: "ConvertArgument"),
+							diagnostic);
+						break;
+				}
+			}
+
+			return Task.CompletedTask;
+		}
+
+		static async Task<Document> RemoveArgumentFixAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var invoke = (InvocationExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+
+			return document.WithSyntaxRoot(
+				root.ReplaceNode(
+					invoke,
+					RemoveArgument(invoke)));
+		}
+
+		static async Task<Document> ConvertArgumentFixAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+		{
+			var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			var invoke = (InvocationExpressionSyntax)root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+
+			return document.WithSyntaxRoot(
+				root.ReplaceNode(
+					invoke,
+					ConvertArgument(invoke)));
+		}
+
+		static SyntaxNode RemoveArgument(InvocationExpressionSyntax invoke)
+		{
+			var argList = invoke.ArgumentList;
+
+			if (invoke.Expression is MemberAccessExpressionSyntax expression &&
+				expression.Name.Identifier.Text != nameof(ILGenerator.Emit))
+			{
+				invoke = invoke.WithExpression(
+					SyntaxFactory.MemberAccessExpression(
+						SyntaxKind.SimpleMemberAccessExpression,
+						expression.Expression,
+						SyntaxFactory.IdentifierName(nameof(ILGenerator.Emit))));
+			}
+
+			return invoke.WithArgumentList(
+				argList.WithArguments(
+					SyntaxFactory.SeparatedList(
+						new[] { argList.Arguments[0] })));
+		}
+
+		static InvocationExpressionSyntax ConvertArgument(InvocationExpressionSyntax invoke)
+		{
+			var argList = invoke.ArgumentList;
+			var field = argList.Arguments[0].Accept(FieldAccessor.Instance);
+
+			if (field == null)
+			{
+				return invoke;
+			}
+
+			var opcode = EmitMatrix.GetOpCode(field.Identifier.Text);
+
+			if (opcode == OpCode.Invalid)
+			{
+				return invoke;
+			}
+
+			var valueArgument = argList.Arguments[1].Expression;
+
+			return invoke.ReplaceNode(
+				valueArgument,
+				valueArgument.Accept(new EmitConversionVisitor(opcode.GetOperand())));
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Emit/EmitConversionVisitor.cs
+++ b/WTG.Analyzers/Analyzers/Emit/EmitConversionVisitor.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	sealed class EmitConversionVisitor : CSharpSyntaxVisitor<ExpressionSyntax>
+	{
+		public EmitConversionVisitor(OpCodeOperand operandType)
+		{
+			this.operandType = operandType;
+		}
+
+		public override ExpressionSyntax DefaultVisit(SyntaxNode node)
+		{
+			return SyntaxFactory.CastExpression(
+				GetCastType(),
+				SyntaxFactory.ParenthesizedExpression((ExpressionSyntax)node)
+					.WithAdditionalAnnotations(Simplifier.Annotation));
+		}
+
+		public override ExpressionSyntax VisitLiteralExpression(LiteralExpressionSyntax node)
+		{
+			if (node.Kind() == SyntaxKind.NumericLiteralExpression)
+			{
+				switch (operandType)
+				{
+					case OpCodeOperand.InlineI:
+						return ExpressionSyntaxFactory.CreateLiteral(Convert.ToInt32(node.Token.Value, CultureInfo.InvariantCulture));
+					case OpCodeOperand.InlineI8:
+						return ExpressionSyntaxFactory.CreateLiteral(Convert.ToInt64(node.Token.Value, CultureInfo.InvariantCulture));
+					case OpCodeOperand.ShortInlineR:
+						return ExpressionSyntaxFactory.CreateLiteral(Convert.ToSingle(node.Token.Value, CultureInfo.InvariantCulture));
+					case OpCodeOperand.InlineR:
+						return ExpressionSyntaxFactory.CreateLiteral(Convert.ToDouble(node.Token.Value, CultureInfo.InvariantCulture));
+				}
+			}
+
+			return base.VisitLiteralExpression(node);
+		}
+
+		public override ExpressionSyntax VisitCastExpression(CastExpressionSyntax node) => node.Expression.Accept(this);
+
+		TypeSyntax GetCastType()
+		{
+			return operandType switch
+			{
+				OpCodeOperand.ShortInlineI => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.SByteKeyword)),
+				OpCodeOperand.ShortInlineVar => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ByteKeyword)),
+
+				OpCodeOperand.InlineI => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
+				OpCodeOperand.InlineVar => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ShortKeyword)),
+
+				OpCodeOperand.InlineI8 => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.LongKeyword)),
+
+				OpCodeOperand.InlineR => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DoubleKeyword)),
+				OpCodeOperand.ShortInlineR => SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.FloatKeyword)),
+
+				_ => null,
+			};
+		}
+
+		readonly OpCodeOperand operandType;
+	}
+}

--- a/WTG.Analyzers/Analyzers/Emit/EmitMatrix.cs
+++ b/WTG.Analyzers/Analyzers/Emit/EmitMatrix.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.CodeAnalysis;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	partial class EmitMatrix
+	{
+		public static bool TryGetEmitMethod(IMethodSymbol method, out EmitMethod emitMethod)
+		{
+			if (!method.ContainingType.IsMatch("System.Reflection.Emit.ILGenerator"))
+			{
+				emitMethod = EmitMethod.None;
+				return false;
+			}
+
+			switch (method.Name)
+			{
+				case nameof(ILGenerator.EmitCall):
+					emitMethod = EmitMethod.EmitCall;
+					break;
+
+				case nameof(ILGenerator.EmitCalli):
+					emitMethod = EmitMethod.EmitCalli;
+					break;
+
+				case nameof(ILGenerator.Emit):
+					emitMethod = GetPlainEmitMethod(method);
+					break;
+
+				default:
+					emitMethod = EmitMethod.None;
+					return false;
+			}
+
+			return true;
+		}
+
+		public static OpCode GetOpCode(IFieldSymbol field)
+		{
+			if (field.ContainingType.IsMatch("System.Reflection.Emit.OpCodes"))
+			{
+				return GetOpCode(field.Name);
+			}
+
+			return OpCode.Invalid;
+		}
+
+		static EmitMethod GetPlainEmitMethod(IMethodSymbol method)
+		{
+			if (method.Parameters.Length == 1)
+			{
+				return EmitMethod.Emit;
+			}
+
+			var argType = method.Parameters[1].Type;
+
+			if (argType.Kind == SymbolKind.ArrayType)
+			{
+				return EmitMethod.Emit_LabelArray;
+			}
+
+			return argType.Name switch
+			{
+				nameof(Byte) => EmitMethod.Emit_Byte,
+				nameof(SByte) => EmitMethod.Emit_SByte,
+				nameof(Int16) => EmitMethod.Emit_Int16,
+				nameof(Int32) => EmitMethod.Emit_Int32,
+				nameof(MethodInfo) => EmitMethod.Emit_MethodInfo,
+				nameof(SignatureHelper) => EmitMethod.Emit_SignatureHelper,
+				nameof(ConstructorInfo) => EmitMethod.Emit_ConstructorInfo,
+				nameof(Type) => EmitMethod.Emit_Type,
+				nameof(Int64) => EmitMethod.Emit_Int64,
+				nameof(Single) => EmitMethod.Emit_Single,
+				nameof(Double) => EmitMethod.Emit_Double,
+				nameof(Label) => EmitMethod.Emit_Label,
+				nameof(FieldInfo) => EmitMethod.Emit_FieldInfo,
+				nameof(String) => EmitMethod.Emit_String,
+				nameof(LocalBuilder) => EmitMethod.Emit_LocalBuilder,
+				_ => EmitMethod.None,
+			};
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Emit/EmitMatrix.g.cs
+++ b/WTG.Analyzers/Analyzers/Emit/EmitMatrix.g.cs
@@ -1,0 +1,1642 @@
+using System;
+
+namespace WTG.Analyzers
+{
+	enum OpCodeOperand
+	{
+		Invalid = 0,
+		InlineBrTarget = 1,
+		InlineField = 2,
+		InlineI = 3,
+		InlineI8 = 4,
+		InlineMethod = 5,
+		InlineNone = 6,
+		InlineR = 7,
+		InlineSig = 8,
+		InlineString = 9,
+		InlineSwitch = 10,
+		InlineTok = 11,
+		InlineType = 12,
+		InlineVar = 13,
+		ShortInlineBrTarget = 14,
+		ShortInlineI = 15,
+		ShortInlineR = 16,
+		ShortInlineVar = 17,
+	}
+
+	[Flags]
+	enum EmitMethod
+	{
+		None = 0,
+		Emit = 1 << 0,
+		Emit_Byte = 1 << 1,
+		Emit_ConstructorInfo = 1 << 2,
+		Emit_Double = 1 << 3,
+		Emit_FieldInfo = 1 << 4,
+		Emit_Int16 = 1 << 5,
+		Emit_Int32 = 1 << 6,
+		Emit_Int64 = 1 << 7,
+		Emit_Label = 1 << 8,
+		Emit_LabelArray = 1 << 9,
+		Emit_LocalBuilder = 1 << 10,
+		Emit_MethodInfo = 1 << 11,
+		Emit_SByte = 1 << 12,
+		Emit_SignatureHelper = 1 << 13,
+		Emit_Single = 1 << 14,
+		Emit_String = 1 << 15,
+		Emit_Type = 1 << 16,
+		EmitCall = 1 << 17,
+		EmitCalli = 1 << 18,
+	}
+
+	enum OpCode
+	{
+		Invalid = 0,
+		#region InlineBrTarget
+
+		/// <summary>
+		/// beq
+		/// </summary>
+		Beq = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bge
+		/// </summary>
+		Bge = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bge.un
+		/// </summary>
+		Bge_Un = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bgt
+		/// </summary>
+		Bgt = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bgt.un
+		/// </summary>
+		Bgt_Un = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// ble
+		/// </summary>
+		Ble = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// ble.un
+		/// </summary>
+		Ble_Un = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// blt
+		/// </summary>
+		Blt = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// blt.un
+		/// </summary>
+		Blt_Un = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bne.un
+		/// </summary>
+		Bne_Un = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// br
+		/// </summary>
+		Br = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// brfalse
+		/// </summary>
+		Brfalse = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// brtrue
+		/// </summary>
+		Brtrue = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// leave
+		/// </summary>
+		Leave = OpCodeOperand.InlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+		#endregion
+		#region InlineField
+
+		/// <summary>
+		/// ldfld
+		/// </summary>
+		Ldfld = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+
+		/// <summary>
+		/// ldflda
+		/// </summary>
+		Ldflda = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+
+		/// <summary>
+		/// ldsfld
+		/// </summary>
+		Ldsfld = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+
+		/// <summary>
+		/// ldsflda
+		/// </summary>
+		Ldsflda = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+
+		/// <summary>
+		/// stfld
+		/// </summary>
+		Stfld = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+
+		/// <summary>
+		/// stsfld
+		/// </summary>
+		Stsfld = OpCodeOperand.InlineField
+			| (EmitMethod.Emit_FieldInfo << 5),
+		#endregion
+		#region InlineI
+
+		/// <summary>
+		/// ldc.i4
+		/// </summary>
+		Ldc_I4 = OpCodeOperand.InlineI
+			| (EmitMethod.Emit_Int32 << 5),
+		#endregion
+		#region InlineI8
+
+		/// <summary>
+		/// ldc.i8
+		/// </summary>
+		Ldc_I8 = OpCodeOperand.InlineI8
+			| (EmitMethod.Emit_Int64 << 5),
+		#endregion
+		#region InlineMethod
+
+		/// <summary>
+		/// call
+		/// </summary>
+		Call = OpCodeOperand.InlineMethod
+			| (EmitMethod.EmitCall << 5)
+			| (EmitMethod.Emit_MethodInfo << 5)
+			| (EmitMethod.Emit_ConstructorInfo << 5),
+
+		/// <summary>
+		/// callvirt
+		/// </summary>
+		Callvirt = OpCodeOperand.InlineMethod
+			| (EmitMethod.EmitCall << 5)
+			| (EmitMethod.Emit_MethodInfo << 5),
+
+		/// <summary>
+		/// jmp
+		/// </summary>
+		Jmp = OpCodeOperand.InlineMethod
+			| (EmitMethod.Emit_MethodInfo << 5),
+
+		/// <summary>
+		/// ldftn
+		/// </summary>
+		Ldftn = OpCodeOperand.InlineMethod
+			| (EmitMethod.Emit_MethodInfo << 5),
+
+		/// <summary>
+		/// ldvirtftn
+		/// </summary>
+		Ldvirtftn = OpCodeOperand.InlineMethod
+			| (EmitMethod.Emit_MethodInfo << 5),
+
+		/// <summary>
+		/// newobj
+		/// </summary>
+		Newobj = OpCodeOperand.InlineMethod
+			| (EmitMethod.Emit_ConstructorInfo << 5),
+		#endregion
+		#region InlineNone
+
+		/// <summary>
+		/// add
+		/// </summary>
+		Add = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// add.ovf
+		/// </summary>
+		Add_Ovf = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// add.ovf.un
+		/// </summary>
+		Add_Ovf_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// and
+		/// </summary>
+		And = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// arglist
+		/// </summary>
+		Arglist = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// break
+		/// </summary>
+		Break = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ceq
+		/// </summary>
+		Ceq = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// cgt
+		/// </summary>
+		Cgt = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// cgt.un
+		/// </summary>
+		Cgt_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ckfinite
+		/// </summary>
+		Ckfinite = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// clt
+		/// </summary>
+		Clt = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// clt.un
+		/// </summary>
+		Clt_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.i
+		/// </summary>
+		Conv_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.i1
+		/// </summary>
+		Conv_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.i2
+		/// </summary>
+		Conv_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.i4
+		/// </summary>
+		Conv_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.i8
+		/// </summary>
+		Conv_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i
+		/// </summary>
+		Conv_Ovf_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i.un
+		/// </summary>
+		Conv_Ovf_I_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i1
+		/// </summary>
+		Conv_Ovf_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i1.un
+		/// </summary>
+		Conv_Ovf_I1_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i2
+		/// </summary>
+		Conv_Ovf_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i2.un
+		/// </summary>
+		Conv_Ovf_I2_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i4
+		/// </summary>
+		Conv_Ovf_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i4.un
+		/// </summary>
+		Conv_Ovf_I4_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i8
+		/// </summary>
+		Conv_Ovf_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.i8.un
+		/// </summary>
+		Conv_Ovf_I8_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u
+		/// </summary>
+		Conv_Ovf_U = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u.un
+		/// </summary>
+		Conv_Ovf_U_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u1
+		/// </summary>
+		Conv_Ovf_U1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u1.un
+		/// </summary>
+		Conv_Ovf_U1_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u2
+		/// </summary>
+		Conv_Ovf_U2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u2.un
+		/// </summary>
+		Conv_Ovf_U2_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u4
+		/// </summary>
+		Conv_Ovf_U4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u4.un
+		/// </summary>
+		Conv_Ovf_U4_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u8
+		/// </summary>
+		Conv_Ovf_U8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.ovf.u8.un
+		/// </summary>
+		Conv_Ovf_U8_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.r.un
+		/// </summary>
+		Conv_R_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.r4
+		/// </summary>
+		Conv_R4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.r8
+		/// </summary>
+		Conv_R8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.u
+		/// </summary>
+		Conv_U = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.u1
+		/// </summary>
+		Conv_U1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.u2
+		/// </summary>
+		Conv_U2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.u4
+		/// </summary>
+		Conv_U4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// conv.u8
+		/// </summary>
+		Conv_U8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// cpblk
+		/// </summary>
+		Cpblk = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// div
+		/// </summary>
+		Div = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// div.un
+		/// </summary>
+		Div_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// dup
+		/// </summary>
+		Dup = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// endfilter
+		/// </summary>
+		Endfilter = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// endfinally
+		/// </summary>
+		Endfinally = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// initblk
+		/// </summary>
+		Initblk = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldarg.0
+		/// </summary>
+		Ldarg_0 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldarg.1
+		/// </summary>
+		Ldarg_1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldarg.2
+		/// </summary>
+		Ldarg_2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldarg.3
+		/// </summary>
+		Ldarg_3 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.0
+		/// </summary>
+		Ldc_I4_0 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.1
+		/// </summary>
+		Ldc_I4_1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.2
+		/// </summary>
+		Ldc_I4_2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.3
+		/// </summary>
+		Ldc_I4_3 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.4
+		/// </summary>
+		Ldc_I4_4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.5
+		/// </summary>
+		Ldc_I4_5 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.6
+		/// </summary>
+		Ldc_I4_6 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.7
+		/// </summary>
+		Ldc_I4_7 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.8
+		/// </summary>
+		Ldc_I4_8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldc.i4.m1
+		/// </summary>
+		Ldc_I4_M1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.i
+		/// </summary>
+		Ldelem_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.i1
+		/// </summary>
+		Ldelem_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.i2
+		/// </summary>
+		Ldelem_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.i4
+		/// </summary>
+		Ldelem_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.i8
+		/// </summary>
+		Ldelem_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.r4
+		/// </summary>
+		Ldelem_R4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.r8
+		/// </summary>
+		Ldelem_R8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.ref
+		/// </summary>
+		Ldelem_Ref = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.u1
+		/// </summary>
+		Ldelem_U1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.u2
+		/// </summary>
+		Ldelem_U2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldelem.u4
+		/// </summary>
+		Ldelem_U4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.i
+		/// </summary>
+		Ldind_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.i1
+		/// </summary>
+		Ldind_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.i2
+		/// </summary>
+		Ldind_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.i4
+		/// </summary>
+		Ldind_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.i8
+		/// </summary>
+		Ldind_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.r4
+		/// </summary>
+		Ldind_R4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.r8
+		/// </summary>
+		Ldind_R8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.ref
+		/// </summary>
+		Ldind_Ref = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.u1
+		/// </summary>
+		Ldind_U1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.u2
+		/// </summary>
+		Ldind_U2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldind.u4
+		/// </summary>
+		Ldind_U4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldlen
+		/// </summary>
+		Ldlen = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldloc.0
+		/// </summary>
+		Ldloc_0 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldloc.1
+		/// </summary>
+		Ldloc_1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldloc.2
+		/// </summary>
+		Ldloc_2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldloc.3
+		/// </summary>
+		Ldloc_3 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ldnull
+		/// </summary>
+		Ldnull = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// localloc
+		/// </summary>
+		Localloc = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// mul
+		/// </summary>
+		Mul = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// mul.ovf
+		/// </summary>
+		Mul_Ovf = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// mul.ovf.un
+		/// </summary>
+		Mul_Ovf_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// neg
+		/// </summary>
+		Neg = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// nop
+		/// </summary>
+		Nop = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// not
+		/// </summary>
+		Not = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// or
+		/// </summary>
+		Or = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// pop
+		/// </summary>
+		Pop = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// readonly.
+		/// </summary>
+		Readonly = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// refanytype
+		/// </summary>
+		Refanytype = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// rem
+		/// </summary>
+		Rem = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// rem.un
+		/// </summary>
+		Rem_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// ret
+		/// </summary>
+		Ret = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// rethrow
+		/// </summary>
+		Rethrow = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// shl
+		/// </summary>
+		Shl = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// shr
+		/// </summary>
+		Shr = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// shr.un
+		/// </summary>
+		Shr_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.i
+		/// </summary>
+		Stelem_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.i1
+		/// </summary>
+		Stelem_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.i2
+		/// </summary>
+		Stelem_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.i4
+		/// </summary>
+		Stelem_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.i8
+		/// </summary>
+		Stelem_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.r4
+		/// </summary>
+		Stelem_R4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.r8
+		/// </summary>
+		Stelem_R8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stelem.ref
+		/// </summary>
+		Stelem_Ref = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.i
+		/// </summary>
+		Stind_I = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.i1
+		/// </summary>
+		Stind_I1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.i2
+		/// </summary>
+		Stind_I2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.i4
+		/// </summary>
+		Stind_I4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.i8
+		/// </summary>
+		Stind_I8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.r4
+		/// </summary>
+		Stind_R4 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.r8
+		/// </summary>
+		Stind_R8 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stind.ref
+		/// </summary>
+		Stind_Ref = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stloc.0
+		/// </summary>
+		Stloc_0 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stloc.1
+		/// </summary>
+		Stloc_1 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stloc.2
+		/// </summary>
+		Stloc_2 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// stloc.3
+		/// </summary>
+		Stloc_3 = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// sub
+		/// </summary>
+		Sub = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// sub.ovf
+		/// </summary>
+		Sub_Ovf = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// sub.ovf.un
+		/// </summary>
+		Sub_Ovf_Un = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// tail.
+		/// </summary>
+		Tailcall = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// throw
+		/// </summary>
+		Throw = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// volatile.
+		/// </summary>
+		Volatile = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+
+		/// <summary>
+		/// xor
+		/// </summary>
+		Xor = OpCodeOperand.InlineNone
+			| (EmitMethod.Emit << 5),
+		#endregion
+		#region InlineR
+
+		/// <summary>
+		/// ldc.r8
+		/// </summary>
+		Ldc_R8 = OpCodeOperand.InlineR
+			| (EmitMethod.Emit_Double << 5),
+		#endregion
+		#region InlineSig
+
+		/// <summary>
+		/// calli
+		/// </summary>
+		Calli = OpCodeOperand.InlineSig
+			| (EmitMethod.EmitCalli << 5)
+			| (EmitMethod.Emit_SignatureHelper << 5),
+		#endregion
+		#region InlineString
+
+		/// <summary>
+		/// ldstr
+		/// </summary>
+		Ldstr = OpCodeOperand.InlineString
+			| (EmitMethod.Emit_String << 5),
+		#endregion
+		#region InlineSwitch
+
+		/// <summary>
+		/// switch
+		/// </summary>
+		Switch = OpCodeOperand.InlineSwitch
+			| (EmitMethod.Emit_LabelArray << 5),
+		#endregion
+		#region InlineTok
+
+		/// <summary>
+		/// ldtoken
+		/// </summary>
+		Ldtoken = OpCodeOperand.InlineTok
+			| (EmitMethod.Emit_Type << 5)
+			| (EmitMethod.Emit_FieldInfo << 5)
+			| (EmitMethod.Emit_MethodInfo << 5),
+		#endregion
+		#region InlineType
+
+		/// <summary>
+		/// box
+		/// </summary>
+		Box = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// castclass
+		/// </summary>
+		Castclass = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// constrained.
+		/// </summary>
+		Constrained = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// cpobj
+		/// </summary>
+		Cpobj = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// initobj
+		/// </summary>
+		Initobj = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// isinst
+		/// </summary>
+		Isinst = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// ldelem
+		/// </summary>
+		Ldelem = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// ldelema
+		/// </summary>
+		Ldelema = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// ldobj
+		/// </summary>
+		Ldobj = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// mkrefany
+		/// </summary>
+		Mkrefany = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// newarr
+		/// </summary>
+		Newarr = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// refanyval
+		/// </summary>
+		Refanyval = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// sizeof
+		/// </summary>
+		Sizeof = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// stelem
+		/// </summary>
+		Stelem = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// stobj
+		/// </summary>
+		Stobj = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// unbox
+		/// </summary>
+		Unbox = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+
+		/// <summary>
+		/// unbox.any
+		/// </summary>
+		Unbox_Any = OpCodeOperand.InlineType
+			| (EmitMethod.Emit_Type << 5),
+		#endregion
+		#region InlineVar
+
+		/// <summary>
+		/// ldarg
+		/// </summary>
+		Ldarg = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5),
+
+		/// <summary>
+		/// ldarga
+		/// </summary>
+		Ldarga = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5),
+
+		/// <summary>
+		/// ldloc
+		/// </summary>
+		Ldloc = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+
+		/// <summary>
+		/// ldloca
+		/// </summary>
+		Ldloca = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+
+		/// <summary>
+		/// starg
+		/// </summary>
+		Starg = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5),
+
+		/// <summary>
+		/// stloc
+		/// </summary>
+		Stloc = OpCodeOperand.InlineVar
+			| (EmitMethod.Emit_Int16 << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+		#endregion
+		#region ShortInlineBrTarget
+
+		/// <summary>
+		/// beq.s
+		/// </summary>
+		Beq_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bge.s
+		/// </summary>
+		Bge_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bge.un.s
+		/// </summary>
+		Bge_Un_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bgt.s
+		/// </summary>
+		Bgt_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bgt.un.s
+		/// </summary>
+		Bgt_Un_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// ble.s
+		/// </summary>
+		Ble_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// ble.un.s
+		/// </summary>
+		Ble_Un_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// blt.s
+		/// </summary>
+		Blt_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// blt.un.s
+		/// </summary>
+		Blt_Un_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// bne.un.s
+		/// </summary>
+		Bne_Un_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// br.s
+		/// </summary>
+		Br_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// brfalse.s
+		/// </summary>
+		Brfalse_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// brtrue.s
+		/// </summary>
+		Brtrue_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+
+		/// <summary>
+		/// leave.s
+		/// </summary>
+		Leave_S = OpCodeOperand.ShortInlineBrTarget
+			| (EmitMethod.Emit_Label << 5),
+		#endregion
+		#region ShortInlineI
+
+		/// <summary>
+		/// ldc.i4.s
+		/// </summary>
+		Ldc_I4_S = OpCodeOperand.ShortInlineI
+			| (EmitMethod.Emit_SByte << 5),
+
+		/// <summary>
+		/// unaligned.
+		/// </summary>
+		Unaligned = OpCodeOperand.ShortInlineI
+			| (EmitMethod.Emit_SByte << 5),
+		#endregion
+		#region ShortInlineR
+
+		/// <summary>
+		/// ldc.r4
+		/// </summary>
+		Ldc_R4 = OpCodeOperand.ShortInlineR
+			| (EmitMethod.Emit_Single << 5),
+		#endregion
+		#region ShortInlineVar
+
+		/// <summary>
+		/// ldarg.s
+		/// </summary>
+		Ldarg_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5),
+
+		/// <summary>
+		/// ldarga.s
+		/// </summary>
+		Ldarga_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5),
+
+		/// <summary>
+		/// ldloc.s
+		/// </summary>
+		Ldloc_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+
+		/// <summary>
+		/// ldloca.s
+		/// </summary>
+		Ldloca_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+
+		/// <summary>
+		/// starg.s
+		/// </summary>
+		Starg_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5),
+
+		/// <summary>
+		/// stloc.s
+		/// </summary>
+		Stloc_S = OpCodeOperand.ShortInlineVar
+			| (EmitMethod.Emit_Byte << 5)
+			| (EmitMethod.Emit_LocalBuilder << 5),
+		#endregion
+	}
+
+	static partial class EmitMatrix
+	{
+		public static OpCodeOperand GetOperand(this OpCode opCode) => (OpCodeOperand)((int)opCode & 0x1F);
+		public static EmitMethod GetSupportedMethods(this OpCode opCode) => (EmitMethod)((int)opCode >> 5 & 0x7FFFF);
+
+		public static OpCode GetOpCode(string field)
+		{
+			return field switch
+			{
+				nameof(OpCode.Add) => OpCode.Add,
+				nameof(OpCode.Add_Ovf) => OpCode.Add_Ovf,
+				nameof(OpCode.Add_Ovf_Un) => OpCode.Add_Ovf_Un,
+				nameof(OpCode.And) => OpCode.And,
+				nameof(OpCode.Arglist) => OpCode.Arglist,
+				nameof(OpCode.Beq) => OpCode.Beq,
+				nameof(OpCode.Beq_S) => OpCode.Beq_S,
+				nameof(OpCode.Bge) => OpCode.Bge,
+				nameof(OpCode.Bge_S) => OpCode.Bge_S,
+				nameof(OpCode.Bge_Un) => OpCode.Bge_Un,
+				nameof(OpCode.Bge_Un_S) => OpCode.Bge_Un_S,
+				nameof(OpCode.Bgt) => OpCode.Bgt,
+				nameof(OpCode.Bgt_S) => OpCode.Bgt_S,
+				nameof(OpCode.Bgt_Un) => OpCode.Bgt_Un,
+				nameof(OpCode.Bgt_Un_S) => OpCode.Bgt_Un_S,
+				nameof(OpCode.Ble) => OpCode.Ble,
+				nameof(OpCode.Ble_S) => OpCode.Ble_S,
+				nameof(OpCode.Ble_Un) => OpCode.Ble_Un,
+				nameof(OpCode.Ble_Un_S) => OpCode.Ble_Un_S,
+				nameof(OpCode.Blt) => OpCode.Blt,
+				nameof(OpCode.Blt_S) => OpCode.Blt_S,
+				nameof(OpCode.Blt_Un) => OpCode.Blt_Un,
+				nameof(OpCode.Blt_Un_S) => OpCode.Blt_Un_S,
+				nameof(OpCode.Bne_Un) => OpCode.Bne_Un,
+				nameof(OpCode.Bne_Un_S) => OpCode.Bne_Un_S,
+				nameof(OpCode.Box) => OpCode.Box,
+				nameof(OpCode.Br) => OpCode.Br,
+				nameof(OpCode.Br_S) => OpCode.Br_S,
+				nameof(OpCode.Break) => OpCode.Break,
+				nameof(OpCode.Brfalse) => OpCode.Brfalse,
+				nameof(OpCode.Brfalse_S) => OpCode.Brfalse_S,
+				nameof(OpCode.Brtrue) => OpCode.Brtrue,
+				nameof(OpCode.Brtrue_S) => OpCode.Brtrue_S,
+				nameof(OpCode.Call) => OpCode.Call,
+				nameof(OpCode.Calli) => OpCode.Calli,
+				nameof(OpCode.Callvirt) => OpCode.Callvirt,
+				nameof(OpCode.Castclass) => OpCode.Castclass,
+				nameof(OpCode.Ceq) => OpCode.Ceq,
+				nameof(OpCode.Cgt) => OpCode.Cgt,
+				nameof(OpCode.Cgt_Un) => OpCode.Cgt_Un,
+				nameof(OpCode.Ckfinite) => OpCode.Ckfinite,
+				nameof(OpCode.Clt) => OpCode.Clt,
+				nameof(OpCode.Clt_Un) => OpCode.Clt_Un,
+				nameof(OpCode.Constrained) => OpCode.Constrained,
+				nameof(OpCode.Conv_I) => OpCode.Conv_I,
+				nameof(OpCode.Conv_I1) => OpCode.Conv_I1,
+				nameof(OpCode.Conv_I2) => OpCode.Conv_I2,
+				nameof(OpCode.Conv_I4) => OpCode.Conv_I4,
+				nameof(OpCode.Conv_I8) => OpCode.Conv_I8,
+				nameof(OpCode.Conv_Ovf_I) => OpCode.Conv_Ovf_I,
+				nameof(OpCode.Conv_Ovf_I_Un) => OpCode.Conv_Ovf_I_Un,
+				nameof(OpCode.Conv_Ovf_I1) => OpCode.Conv_Ovf_I1,
+				nameof(OpCode.Conv_Ovf_I1_Un) => OpCode.Conv_Ovf_I1_Un,
+				nameof(OpCode.Conv_Ovf_I2) => OpCode.Conv_Ovf_I2,
+				nameof(OpCode.Conv_Ovf_I2_Un) => OpCode.Conv_Ovf_I2_Un,
+				nameof(OpCode.Conv_Ovf_I4) => OpCode.Conv_Ovf_I4,
+				nameof(OpCode.Conv_Ovf_I4_Un) => OpCode.Conv_Ovf_I4_Un,
+				nameof(OpCode.Conv_Ovf_I8) => OpCode.Conv_Ovf_I8,
+				nameof(OpCode.Conv_Ovf_I8_Un) => OpCode.Conv_Ovf_I8_Un,
+				nameof(OpCode.Conv_Ovf_U) => OpCode.Conv_Ovf_U,
+				nameof(OpCode.Conv_Ovf_U_Un) => OpCode.Conv_Ovf_U_Un,
+				nameof(OpCode.Conv_Ovf_U1) => OpCode.Conv_Ovf_U1,
+				nameof(OpCode.Conv_Ovf_U1_Un) => OpCode.Conv_Ovf_U1_Un,
+				nameof(OpCode.Conv_Ovf_U2) => OpCode.Conv_Ovf_U2,
+				nameof(OpCode.Conv_Ovf_U2_Un) => OpCode.Conv_Ovf_U2_Un,
+				nameof(OpCode.Conv_Ovf_U4) => OpCode.Conv_Ovf_U4,
+				nameof(OpCode.Conv_Ovf_U4_Un) => OpCode.Conv_Ovf_U4_Un,
+				nameof(OpCode.Conv_Ovf_U8) => OpCode.Conv_Ovf_U8,
+				nameof(OpCode.Conv_Ovf_U8_Un) => OpCode.Conv_Ovf_U8_Un,
+				nameof(OpCode.Conv_R_Un) => OpCode.Conv_R_Un,
+				nameof(OpCode.Conv_R4) => OpCode.Conv_R4,
+				nameof(OpCode.Conv_R8) => OpCode.Conv_R8,
+				nameof(OpCode.Conv_U) => OpCode.Conv_U,
+				nameof(OpCode.Conv_U1) => OpCode.Conv_U1,
+				nameof(OpCode.Conv_U2) => OpCode.Conv_U2,
+				nameof(OpCode.Conv_U4) => OpCode.Conv_U4,
+				nameof(OpCode.Conv_U8) => OpCode.Conv_U8,
+				nameof(OpCode.Cpblk) => OpCode.Cpblk,
+				nameof(OpCode.Cpobj) => OpCode.Cpobj,
+				nameof(OpCode.Div) => OpCode.Div,
+				nameof(OpCode.Div_Un) => OpCode.Div_Un,
+				nameof(OpCode.Dup) => OpCode.Dup,
+				nameof(OpCode.Endfilter) => OpCode.Endfilter,
+				nameof(OpCode.Endfinally) => OpCode.Endfinally,
+				nameof(OpCode.Initblk) => OpCode.Initblk,
+				nameof(OpCode.Initobj) => OpCode.Initobj,
+				nameof(OpCode.Isinst) => OpCode.Isinst,
+				nameof(OpCode.Jmp) => OpCode.Jmp,
+				nameof(OpCode.Ldarg) => OpCode.Ldarg,
+				nameof(OpCode.Ldarg_0) => OpCode.Ldarg_0,
+				nameof(OpCode.Ldarg_1) => OpCode.Ldarg_1,
+				nameof(OpCode.Ldarg_2) => OpCode.Ldarg_2,
+				nameof(OpCode.Ldarg_3) => OpCode.Ldarg_3,
+				nameof(OpCode.Ldarg_S) => OpCode.Ldarg_S,
+				nameof(OpCode.Ldarga) => OpCode.Ldarga,
+				nameof(OpCode.Ldarga_S) => OpCode.Ldarga_S,
+				nameof(OpCode.Ldc_I4) => OpCode.Ldc_I4,
+				nameof(OpCode.Ldc_I4_0) => OpCode.Ldc_I4_0,
+				nameof(OpCode.Ldc_I4_1) => OpCode.Ldc_I4_1,
+				nameof(OpCode.Ldc_I4_2) => OpCode.Ldc_I4_2,
+				nameof(OpCode.Ldc_I4_3) => OpCode.Ldc_I4_3,
+				nameof(OpCode.Ldc_I4_4) => OpCode.Ldc_I4_4,
+				nameof(OpCode.Ldc_I4_5) => OpCode.Ldc_I4_5,
+				nameof(OpCode.Ldc_I4_6) => OpCode.Ldc_I4_6,
+				nameof(OpCode.Ldc_I4_7) => OpCode.Ldc_I4_7,
+				nameof(OpCode.Ldc_I4_8) => OpCode.Ldc_I4_8,
+				nameof(OpCode.Ldc_I4_M1) => OpCode.Ldc_I4_M1,
+				nameof(OpCode.Ldc_I4_S) => OpCode.Ldc_I4_S,
+				nameof(OpCode.Ldc_I8) => OpCode.Ldc_I8,
+				nameof(OpCode.Ldc_R4) => OpCode.Ldc_R4,
+				nameof(OpCode.Ldc_R8) => OpCode.Ldc_R8,
+				nameof(OpCode.Ldelem) => OpCode.Ldelem,
+				nameof(OpCode.Ldelem_I) => OpCode.Ldelem_I,
+				nameof(OpCode.Ldelem_I1) => OpCode.Ldelem_I1,
+				nameof(OpCode.Ldelem_I2) => OpCode.Ldelem_I2,
+				nameof(OpCode.Ldelem_I4) => OpCode.Ldelem_I4,
+				nameof(OpCode.Ldelem_I8) => OpCode.Ldelem_I8,
+				nameof(OpCode.Ldelem_R4) => OpCode.Ldelem_R4,
+				nameof(OpCode.Ldelem_R8) => OpCode.Ldelem_R8,
+				nameof(OpCode.Ldelem_Ref) => OpCode.Ldelem_Ref,
+				nameof(OpCode.Ldelem_U1) => OpCode.Ldelem_U1,
+				nameof(OpCode.Ldelem_U2) => OpCode.Ldelem_U2,
+				nameof(OpCode.Ldelem_U4) => OpCode.Ldelem_U4,
+				nameof(OpCode.Ldelema) => OpCode.Ldelema,
+				nameof(OpCode.Ldfld) => OpCode.Ldfld,
+				nameof(OpCode.Ldflda) => OpCode.Ldflda,
+				nameof(OpCode.Ldftn) => OpCode.Ldftn,
+				nameof(OpCode.Ldind_I) => OpCode.Ldind_I,
+				nameof(OpCode.Ldind_I1) => OpCode.Ldind_I1,
+				nameof(OpCode.Ldind_I2) => OpCode.Ldind_I2,
+				nameof(OpCode.Ldind_I4) => OpCode.Ldind_I4,
+				nameof(OpCode.Ldind_I8) => OpCode.Ldind_I8,
+				nameof(OpCode.Ldind_R4) => OpCode.Ldind_R4,
+				nameof(OpCode.Ldind_R8) => OpCode.Ldind_R8,
+				nameof(OpCode.Ldind_Ref) => OpCode.Ldind_Ref,
+				nameof(OpCode.Ldind_U1) => OpCode.Ldind_U1,
+				nameof(OpCode.Ldind_U2) => OpCode.Ldind_U2,
+				nameof(OpCode.Ldind_U4) => OpCode.Ldind_U4,
+				nameof(OpCode.Ldlen) => OpCode.Ldlen,
+				nameof(OpCode.Ldloc) => OpCode.Ldloc,
+				nameof(OpCode.Ldloc_0) => OpCode.Ldloc_0,
+				nameof(OpCode.Ldloc_1) => OpCode.Ldloc_1,
+				nameof(OpCode.Ldloc_2) => OpCode.Ldloc_2,
+				nameof(OpCode.Ldloc_3) => OpCode.Ldloc_3,
+				nameof(OpCode.Ldloc_S) => OpCode.Ldloc_S,
+				nameof(OpCode.Ldloca) => OpCode.Ldloca,
+				nameof(OpCode.Ldloca_S) => OpCode.Ldloca_S,
+				nameof(OpCode.Ldnull) => OpCode.Ldnull,
+				nameof(OpCode.Ldobj) => OpCode.Ldobj,
+				nameof(OpCode.Ldsfld) => OpCode.Ldsfld,
+				nameof(OpCode.Ldsflda) => OpCode.Ldsflda,
+				nameof(OpCode.Ldstr) => OpCode.Ldstr,
+				nameof(OpCode.Ldtoken) => OpCode.Ldtoken,
+				nameof(OpCode.Ldvirtftn) => OpCode.Ldvirtftn,
+				nameof(OpCode.Leave) => OpCode.Leave,
+				nameof(OpCode.Leave_S) => OpCode.Leave_S,
+				nameof(OpCode.Localloc) => OpCode.Localloc,
+				nameof(OpCode.Mkrefany) => OpCode.Mkrefany,
+				nameof(OpCode.Mul) => OpCode.Mul,
+				nameof(OpCode.Mul_Ovf) => OpCode.Mul_Ovf,
+				nameof(OpCode.Mul_Ovf_Un) => OpCode.Mul_Ovf_Un,
+				nameof(OpCode.Neg) => OpCode.Neg,
+				nameof(OpCode.Newarr) => OpCode.Newarr,
+				nameof(OpCode.Newobj) => OpCode.Newobj,
+				nameof(OpCode.Nop) => OpCode.Nop,
+				nameof(OpCode.Not) => OpCode.Not,
+				nameof(OpCode.Or) => OpCode.Or,
+				nameof(OpCode.Pop) => OpCode.Pop,
+				nameof(OpCode.Readonly) => OpCode.Readonly,
+				nameof(OpCode.Refanytype) => OpCode.Refanytype,
+				nameof(OpCode.Refanyval) => OpCode.Refanyval,
+				nameof(OpCode.Rem) => OpCode.Rem,
+				nameof(OpCode.Rem_Un) => OpCode.Rem_Un,
+				nameof(OpCode.Ret) => OpCode.Ret,
+				nameof(OpCode.Rethrow) => OpCode.Rethrow,
+				nameof(OpCode.Shl) => OpCode.Shl,
+				nameof(OpCode.Shr) => OpCode.Shr,
+				nameof(OpCode.Shr_Un) => OpCode.Shr_Un,
+				nameof(OpCode.Sizeof) => OpCode.Sizeof,
+				nameof(OpCode.Starg) => OpCode.Starg,
+				nameof(OpCode.Starg_S) => OpCode.Starg_S,
+				nameof(OpCode.Stelem) => OpCode.Stelem,
+				nameof(OpCode.Stelem_I) => OpCode.Stelem_I,
+				nameof(OpCode.Stelem_I1) => OpCode.Stelem_I1,
+				nameof(OpCode.Stelem_I2) => OpCode.Stelem_I2,
+				nameof(OpCode.Stelem_I4) => OpCode.Stelem_I4,
+				nameof(OpCode.Stelem_I8) => OpCode.Stelem_I8,
+				nameof(OpCode.Stelem_R4) => OpCode.Stelem_R4,
+				nameof(OpCode.Stelem_R8) => OpCode.Stelem_R8,
+				nameof(OpCode.Stelem_Ref) => OpCode.Stelem_Ref,
+				nameof(OpCode.Stfld) => OpCode.Stfld,
+				nameof(OpCode.Stind_I) => OpCode.Stind_I,
+				nameof(OpCode.Stind_I1) => OpCode.Stind_I1,
+				nameof(OpCode.Stind_I2) => OpCode.Stind_I2,
+				nameof(OpCode.Stind_I4) => OpCode.Stind_I4,
+				nameof(OpCode.Stind_I8) => OpCode.Stind_I8,
+				nameof(OpCode.Stind_R4) => OpCode.Stind_R4,
+				nameof(OpCode.Stind_R8) => OpCode.Stind_R8,
+				nameof(OpCode.Stind_Ref) => OpCode.Stind_Ref,
+				nameof(OpCode.Stloc) => OpCode.Stloc,
+				nameof(OpCode.Stloc_0) => OpCode.Stloc_0,
+				nameof(OpCode.Stloc_1) => OpCode.Stloc_1,
+				nameof(OpCode.Stloc_2) => OpCode.Stloc_2,
+				nameof(OpCode.Stloc_3) => OpCode.Stloc_3,
+				nameof(OpCode.Stloc_S) => OpCode.Stloc_S,
+				nameof(OpCode.Stobj) => OpCode.Stobj,
+				nameof(OpCode.Stsfld) => OpCode.Stsfld,
+				nameof(OpCode.Sub) => OpCode.Sub,
+				nameof(OpCode.Sub_Ovf) => OpCode.Sub_Ovf,
+				nameof(OpCode.Sub_Ovf_Un) => OpCode.Sub_Ovf_Un,
+				nameof(OpCode.Switch) => OpCode.Switch,
+				nameof(OpCode.Tailcall) => OpCode.Tailcall,
+				nameof(OpCode.Throw) => OpCode.Throw,
+				nameof(OpCode.Unaligned) => OpCode.Unaligned,
+				nameof(OpCode.Unbox) => OpCode.Unbox,
+				nameof(OpCode.Unbox_Any) => OpCode.Unbox_Any,
+				nameof(OpCode.Volatile) => OpCode.Volatile,
+				nameof(OpCode.Xor) => OpCode.Xor,
+				_ => OpCode.Invalid,
+			};
+		}
+	}
+}

--- a/WTG.Analyzers/Analyzers/Emit/EmitMatrix.tt
+++ b/WTG.Analyzers/Analyzers/Emit/EmitMatrix.tt
@@ -1,0 +1,209 @@
+<#@ template debug="true" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Collections" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Reflection" #>
+<#@ import namespace="System.Reflection.Emit" #>
+<#@ output extension=".g.cs" #>
+<#
+var fields = Enumerable.ToArray(
+	from field in typeof(OpCodes).GetFields()
+	where field.IsStatic && field.FieldType == typeof(OpCode)
+	orderby field.Name
+	let opCode = (OpCode)field.GetValue(null)
+	where opCode.OpCodeType != OpCodeType.Nternal
+	select new
+	{
+		Name = field.Name,
+		Mnumonic = opCode.Name,
+		OperandType = opCode.OperandType,
+		MethodNames = GetMethodNames(opCode),
+	});
+
+var fieldsByOperand = Enumerable.ToArray(
+	from field in fields
+	group field by field.OperandType into g
+	let result = new
+	{
+		Key = g.Key.ToString(),
+		Fields = g.ToArray(),
+	}
+	orderby result.Key
+	select result);
+
+var allMethodsNames = methodOverride
+	.Values
+	.Concat(methodDefault.Values)
+	.SelectMany(x => x)
+	.Distinct()
+	.OrderBy(x => x)
+	.ToArray();
+
+var opCodeOperandBits = RequiredBits(fieldsByOperand.Length);
+var methodBits = allMethodsNames.Length;
+#>
+using System;
+
+namespace WTG.Analyzers
+{
+	enum OpCodeOperand
+	{
+		Invalid = 0,
+<#
+var index = 0;
+
+foreach (var fieldGroup in fieldsByOperand)
+{
+#>
+		<#=fieldGroup.Key#> = <#=++index#>,
+<#
+}
+#>
+	}
+
+	[Flags]
+	enum EmitMethod
+	{
+		None = 0,
+<#
+
+{
+	var i = 0;
+
+	foreach (var methodName in allMethodsNames)
+	{
+#>
+		<#=methodName#> = 1 << <#=i++#>,
+<#
+	}
+}
+#>
+	}
+
+	enum OpCode
+	{
+		Invalid = 0,
+<#
+foreach (var fieldGroup in fieldsByOperand)
+{
+#>
+		#region <#=fieldGroup.Key#>
+<#
+	foreach (var field in fieldGroup.Fields)
+	{
+#>
+
+		/// <summary>
+		/// <#=field.Mnumonic#>
+		/// </summary>
+		<#=field.Name#> = OpCodeOperand.<#=field.OperandType#><#
+		foreach (var methodName in field.MethodNames)
+		{
+			#>
+
+			| (EmitMethod.<#=methodName#> << <#=opCodeOperandBits#>)<#
+		}
+			#>,
+<#
+	}
+#>
+		#endregion
+<#
+}
+#>
+	}
+
+	static partial class EmitMatrix
+	{
+		public static OpCodeOperand GetOperand(this OpCode opCode) => (OpCodeOperand)((int)opCode & 0x<#=((1 << opCodeOperandBits) - 1).ToString("X")#>);
+		public static EmitMethod GetSupportedMethods(this OpCode opCode) => (EmitMethod)((int)opCode >> <#=opCodeOperandBits#> & 0x<#=((1 << methodBits) - 1).ToString("X")#>);
+
+		public static OpCode GetOpCode(string field)
+		{
+			return field switch
+			{
+<#
+foreach (var field in fields)
+{
+#>
+				nameof(OpCode.<#=field.Name#>) => OpCode.<#=field.Name#>,
+<#
+}
+#>
+				_ => OpCode.Invalid,
+			};
+		}
+	}
+}
+<#+
+static int RequiredBits(int value)
+{
+	var count = 0;
+	var tmp = unchecked((uint)value);
+
+	while (tmp != 0)
+	{
+		count++;
+		tmp >>= 1;
+	}
+
+	return count;
+}
+
+IEnumerable<string> GetMethodNames(OpCode opcode)
+{
+	IEnumerable<string> result;
+
+	if (!methodOverride.TryGetValue(opcode.Name, out result) &&
+		!methodDefault.TryGetValue(opcode.OperandType, out result))
+	{
+		result = Enumerable.Empty<string>();
+	}
+
+	return result;
+}
+
+static readonly IReadOnlyDictionary<string, IEnumerable<string>> methodOverride = new Dictionary<string, IEnumerable<string>>()
+{
+	{ "ldvirtftn", new[] { "Emit_MethodInfo" }},
+	{ "newobj",    new[] { "Emit_ConstructorInfo" }},
+
+	{ "ldarg",     new[] { "Emit_Int16" }},
+	{ "ldarga",    new[] { "Emit_Int16" }},
+	{ "starg",     new[] { "Emit_Int16" }},
+
+	{ "ldarg.s",   new[] { "Emit_Byte" }},
+	{ "ldarga.s",  new[] { "Emit_Byte" }},
+	{ "starg.s",   new[] { "Emit_Byte" }},
+
+	{ "call",      new[] { "EmitCall", "Emit_MethodInfo", "Emit_ConstructorInfo" }},
+	{ "callvirt",  new[] { "EmitCall", "Emit_MethodInfo" }},
+	{ "calli",     new[] { "EmitCalli", "Emit_SignatureHelper" }},
+};
+
+static readonly IReadOnlyDictionary<OperandType, IEnumerable<string>> methodDefault = new Dictionary<OperandType, IEnumerable<string>>()
+{
+	{ OperandType.InlineNone,          new[] { "Emit" }},
+
+	{ OperandType.InlineI,             new[] { "Emit_Int32" }},
+	{ OperandType.InlineI8,            new[] { "Emit_Int64" }},
+	{ OperandType.InlineR,             new[] { "Emit_Double" }},
+	{ OperandType.ShortInlineI,        new[] { "Emit_SByte" }},
+	{ OperandType.ShortInlineR,        new[] { "Emit_Single" }},
+
+	{ OperandType.InlineVar,           new[] { "Emit_Int16", "Emit_LocalBuilder" }},
+	{ OperandType.ShortInlineVar,      new[] { "Emit_Byte",  "Emit_LocalBuilder" }},
+
+	{ OperandType.InlineBrTarget,      new[] { "Emit_Label" }},
+	{ OperandType.InlineSwitch,        new[] { "Emit_LabelArray" }},
+	{ OperandType.ShortInlineBrTarget, new[] { "Emit_Label" }},
+
+	{ OperandType.InlineString,        new[] { "Emit_String" }},
+	{ OperandType.InlineTok,           new[] { "Emit_Type", "Emit_FieldInfo", "Emit_MethodInfo" }},
+	{ OperandType.InlineType,          new[] { "Emit_Type" }},
+	{ OperandType.InlineField,         new[] { "Emit_FieldInfo" }},
+	{ OperandType.InlineMethod,        new[] { "Emit_MethodInfo" }},
+	{ OperandType.InlineSig,           new[] { "Emit_SignatureHelper" }},
+};
+#>

--- a/WTG.Analyzers/Analyzers/Emit/FieldAccessor.cs
+++ b/WTG.Analyzers/Analyzers/Emit/FieldAccessor.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace WTG.Analyzers
+{
+	sealed class FieldAccessor : CSharpSyntaxVisitor<SimpleNameSyntax>
+	{
+		public static FieldAccessor Instance { get; } = new FieldAccessor();
+
+		FieldAccessor()
+		{
+		}
+
+		public override SimpleNameSyntax VisitIdentifierName(IdentifierNameSyntax node) => node;
+		public override SimpleNameSyntax VisitArgument(ArgumentSyntax node) => node.Expression.Accept(this);
+		public override SimpleNameSyntax VisitParenthesizedExpression(ParenthesizedExpressionSyntax node) => node.Expression.Accept(this);
+		public override SimpleNameSyntax VisitMemberAccessExpression(MemberAccessExpressionSyntax node) => node.Name;
+	}
+}

--- a/WTG.Analyzers/Rules/Rules.g.cs
+++ b/WTG.Analyzers/Rules/Rules.g.cs
@@ -29,6 +29,7 @@ namespace WTG.Analyzers
 		public const string AvoidConditionalCompilationBasedOnDebugDiagnosticID = "WTG2002";
 		public const string FlagEnumsShouldSpecifyExplicitValuesDiagnosticID = "WTG2003";
 		public const string DoNotUseCodeContractsDiagnosticID = "WTG2004";
+		public const string UseCorrectEmitOverloadDiagnosticID = "WTG2005";
 		public const string RemovedOrphanedSuppressionsDiagnosticID = "WTG3001";
 		public const string PreferDirectMemberAccessOverLinqDiagnosticID = "WTG3002";
 		public const string PreferDirectMemberAccessOverLinqInAnExpressionDiagnosticID = "WTG3003";
@@ -275,6 +276,24 @@ namespace WTG.Analyzers
 			{
 				WellKnownDiagnosticTags.Unnecessary,
 			});
+
+		public static readonly DiagnosticDescriptor UseCorrectEmitOverloadRule = new DiagnosticDescriptor(
+			UseCorrectEmitOverloadDiagnosticID,
+			"Use Correct Emit Overload",
+			"The {0} opcode cannot be used with this emit overload.",
+			CorrectnessCategory,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "The emit methods generally don't pay attention to the opcode when emitting the operand, so using the wrong overload may result in unexpected behaviour that is difficult to debug.");
+
+		public static readonly DiagnosticDescriptor UseCorrectEmitOverload_NoneRule = new DiagnosticDescriptor(
+			UseCorrectEmitOverloadDiagnosticID,
+			"Use Correct Emit Overload",
+			"The {0} opcode does not take an argument.",
+			CorrectnessCategory,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "The emit methods generally don't pay attention to the opcode when emitting the operand, so using the wrong overload may result in unexpected behaviour that is difficult to debug.");
 
 		public static readonly DiagnosticDescriptor RemovedOrphanedSuppressionsRule = new DiagnosticDescriptor(
 			RemovedOrphanedSuppressionsDiagnosticID,
@@ -661,6 +680,22 @@ namespace WTG.Analyzers
 		public static Diagnostic CreateDoNotUseCodeContractsDiagnostic(Location location)
 		{
 			return Diagnostic.Create(DoNotUseCodeContractsRule, location);
+		}
+
+		/// <summary>
+		/// The {opcode} opcode cannot be used with this emit overload.
+		/// </summary>
+		public static Diagnostic CreateUseCorrectEmitOverloadDiagnostic(Location location, object opcode)
+		{
+			return Diagnostic.Create(UseCorrectEmitOverloadRule, location, opcode);
+		}
+
+		/// <summary>
+		/// The {opcode} opcode does not take an argument.
+		/// </summary>
+		public static Diagnostic CreateUseCorrectEmitOverload_NoneDiagnostic(Location location, object opcode)
+		{
+			return Diagnostic.Create(UseCorrectEmitOverload_NoneRule, location, opcode);
 		}
 
 		/// <summary>

--- a/WTG.Analyzers/Rules/Rules.xml
+++ b/WTG.Analyzers/Rules/Rules.xml
@@ -118,6 +118,12 @@
 			<description>References to Code Contracs should be replaced with alternate forms of checking or should be deleted.</description>
 			<tag>Unnecessary</tag>
 		</rule>
+		<rule id="5" name="UseCorrectEmitOverload" severity="Warning">
+			<title>Use Correct Emit Overload</title>
+			<message>The {opcode} opcode cannot be used with this emit overload.</message>
+			<message name="None">The {opcode} opcode does not take an argument.</message>
+			<description>The emit methods generally don't pay attention to the opcode when emitting the operand, so using the wrong overload may result in unexpected behaviour that is difficult to debug.</description>
+		</rule>
 	</category>
 	<category name="Decruftification" id="3000">
 		<rule id="1" name="RemovedOrphanedSuppressions" severity="Info">

--- a/WTG.Analyzers/WTG.Analyzers.csproj
+++ b/WTG.Analyzers/WTG.Analyzers.csproj
@@ -10,10 +10,20 @@
     <ProjectReference Include="..\WTG.Analyzers.Utils\WTG.Analyzers.Utils.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Analyzers\Emit\EmitMatrix.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>EmitMatrix.g.cs</LastGenOutput>
+    </None>
     <None Update="Rules\Rules.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Rules.g.cs</LastGenOutput>
     </None>
+    <Compile Update="Analyzers\Emit\EmitMatrix.g.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>EmitMatrix.tt</DependentUpon>
+    </Compile>
+
     <Compile Update="Rules\Rules.g.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Adds a rule to validate that the `ILGenerator.Emit` overload used is valid for specified `OpCode`. This is because the overload determines what bytes are emitted for the argument, but the opcode determines how those bytes will be interpreted ... and the emit method generally doesn't verify that they are the same.