### PR TITLE
Fix NU5128 warning.

### DIFF
--- a/WTG.Analyzers.TestFramework.nuspec
+++ b/WTG.Analyzers.TestFramework.nuspec
@@ -11,11 +11,16 @@
 		<copyright>Copyright 2018</copyright>
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<developmentDependency>true</developmentDependency>
+		<dependencies>
+			<group targetFramework=".NETFramework4.6" />
+			<group targetFramework=".NETStandard2.0" />
+		</dependencies>
 	</metadata>
 
 	<files>
 		<!-- Binaries -->
 		<file src="bin\net46\WTG.Analyzers.TestFramework.dll" target="lib\net46" />
+		<file src="bin\netstandard2.0\WTG.Analyzers.TestFramework.dll" target="lib\netstandard2.0" />
 
 		<!-- Other -->
 		<file src="LICENSE.md" target="" />

--- a/WTG.Analyzers.Utils.nuspec
+++ b/WTG.Analyzers.Utils.nuspec
@@ -11,7 +11,9 @@
 		<copyright>Copyright 2018</copyright>
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<dependencies>
-			<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.0.0" />
+			<group targetFramework=".NETStandard1.3">
+				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.0.0" />
+			</group>
 		</dependencies>
 	</metadata>
 


### PR DESCRIPTION
If I update NuGet.CommandLine or start using `dotnet pack`, then I start getting the [NU5128](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) warning. This fixes the warning in preparation for whichever approach we eventually decide to take.

> WARNING: NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location.

Also, since WTG.Analyzers.TestFramework is already building a netstandard2.0 version, I figured we might as well stick it in the nuget package too.