### PR TITLE
Removed CommonAssemblyInfo.cs

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<BuildDirectory>$(MSBuildThisFileDirectory)build\</BuildDirectory>
 		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -34,10 +34,6 @@
 	<PropertyGroup Condition="'$(RunCodeAnalysis)' == 'True'">
 		<DebugType>full</DebugType>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
-	</ItemGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory).paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
The CommonAssemblyInfo.cs file has long since been superseded by the build-time generated AssemblyInfo files. The only thing CommonAssemblyInfo.cs does now is disabling com visibility, but I don't think we need to care about that (We used to add it to satisfy legacy FxCop, but FxCopAnalyzers doesn't seem to care).