### PR TITLE
CodeFixer should only attempt to fix the fixable issues.

### DIFF
--- a/WTG.Analyzers/Analyzers/Var/VarCodeFixProvider.cs
+++ b/WTG.Analyzers/Analyzers/Var/VarCodeFixProvider.cs
@@ -19,7 +19,8 @@ namespace WTG.Analyzers
 
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
 			Rules.UseVarWherePossibleDiagnosticID,
-			Rules.UseOutVarWherePossibleDiagnosticID);
+			Rules.UseOutVarWherePossibleDiagnosticID,
+			Rules.DeconstructWithVarDiagnosticID);
 
 		public sealed override FixAllProvider GetFixAllProvider() => VarFixAllProvider.Instance;
 


### PR DESCRIPTION
Currently `CodeFixer` asks the `CodeFixProvider` to fix all reported issues, including those not actually reported by the corresponding analyzer (which occasionally results in an invalid exception). This also means that our tests didn't notice when a `CodeFixProvider` failed to report all the issue ids that it can fix.