### PR TITLE
FIX NRE in RegexAnalyzer when invoking a return result.

### DIFF
--- a/WTG.Analyzers.Test/TestData/RegexAnalyzer/InvokeNotOnIdentifier.Source.cs
+++ b/WTG.Analyzers.Test/TestData/RegexAnalyzer/InvokeNotOnIdentifier.Source.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Magic
+{
+	class A
+	{
+		public void Method()
+		{
+			Foo()();
+		}
+
+		static Action Foo() => null;
+	}
+}

--- a/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
+++ b/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
@@ -54,13 +54,24 @@ namespace WTG.Analyzers.TestFramework
 		{
 			var descriptor = diag.Descriptor;
 
-			return descriptor.DefaultSeverity == DiagnosticSeverity.Error
-				&& descriptor.CustomTags.Any(x => CriticalTags.Contains(x));
-		}
+			foreach (var tag in descriptor.CustomTags)
+			{
+				switch (tag)
+				{
+					case WellKnownDiagnosticTags.AnalyzerException:
+						return true;
 
-		static readonly ImmutableHashSet<string> CriticalTags = ImmutableHashSet.Create(
-			WellKnownDiagnosticTags.Build,
-			WellKnownDiagnosticTags.Compiler,
-			WellKnownDiagnosticTags.AnalyzerException);
+					case WellKnownDiagnosticTags.Build:
+					case WellKnownDiagnosticTags.Compiler:
+						if (descriptor.DefaultSeverity == DiagnosticSeverity.Error)
+						{
+							return true;
+						}
+						break;
+				}
+			}
+
+			return false;
+		}
 	}
 }

--- a/WTG.Analyzers/Analyzers/Regex/RegexAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/Regex/RegexAnalyzer.cs
@@ -52,7 +52,7 @@ namespace WTG.Analyzers
 
 		static bool IsTargetMethod(SemanticModel model, InvocationExpressionSyntax invoke, out int index, CancellationToken cancellationToken)
 		{
-			var name = ExpressionHelper.GetMethodName(invoke).Identifier.Text;
+			var name = ExpressionHelper.GetMethodName(invoke)?.Identifier.Text;
 
 			switch (name)
 			{


### PR DESCRIPTION
Fixes #110 
Also, the test framework was ignoring AD0001 diagnostics because they are warnings and not errors.