### PR TITLE
Add analyzer to forbid setting custom HTTP ReasonPhrase values

### DIFF
--- a/WTG.Analyzers.Test/AnalyzerOnlyTest.cs
+++ b/WTG.Analyzers.Test/AnalyzerOnlyTest.cs
@@ -13,6 +13,7 @@ namespace WTG.Analyzers.Test
 	[TestFixture(TypeArgs = new[] { typeof(ConditionalOperandAnalyzer) })]
 	[TestFixture(TypeArgs = new[] { typeof(ConditionDirectiveAnalyzer) })]
 	[TestFixture(TypeArgs = new[] { typeof(DiscardVariableAnalyzer) })]
+	[TestFixture(TypeArgs = new[] { typeof(HttpReasonPhraseAnalyzer) })]
 	[TestFixture(TypeArgs = new[] { typeof(NestedConditionalAnalyzer) })]
 	[TestFixture(TypeArgs = new[] { typeof(PublicTupleTypeAnalyzer) })]
 	public class AnalyzerTest<TAnalyzer>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
@@ -3,4 +3,7 @@
 	<diagnostic>
 		<location>Test0.cs: (15,3-32)</location>
 	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (16,3-38)</location>
+	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
@@ -7,6 +7,6 @@
 		<location>Test0.cs: (16,3-38)</location>
 	</diagnostic>
 	<diagnostic>
-		<location>Test0.cs: (17,33-54)</location>
+		<location>Test0.cs: (17,33-53)</location>
 	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG2007" message="Do not use custom values for the Reason Phrase portion of a HTTP response." severity="Warning">
+	<diagnostic>
+		<location>Test0.cs: (15,3-32)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Diagnostics.xml
@@ -6,4 +6,7 @@
 	<diagnostic>
 		<location>Test0.cs: (16,3-38)</location>
 	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (17,33-54)</location>
+	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
@@ -13,5 +13,10 @@ class Foo
 	public void Method(HttpResponseMessage response)
 	{
 		response.ReasonPhrase = "foo";
+		Log(response.ReasonPhrase);
+	}
+
+	void Log(string value)
+	{
 	}
 }

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
@@ -14,7 +14,7 @@ class Foo
 	{
 		response.ReasonPhrase = "foo";
 		response.ReasonPhrase += "suffixed";
-		_ = new HttpResponseMessage { ReasonPhrase = "bar " };
+		_ = new HttpResponseMessage { ReasonPhrase = "bar" };
 
 		Log(response.ReasonPhrase);
 	}

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
@@ -14,6 +14,7 @@ class Foo
 	{
 		response.ReasonPhrase = "foo";
 		response.ReasonPhrase += "suffixed";
+		_ = new HttpResponseMessage { ReasonPhrase = "bar " };
 
 		Log(response.ReasonPhrase);
 	}

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
@@ -13,6 +13,8 @@ class Foo
 	public void Method(HttpResponseMessage response)
 	{
 		response.ReasonPhrase = "foo";
+		response.ReasonPhrase += "suffixed";
+
 		Log(response.ReasonPhrase);
 	}
 

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/HttpResponseMessage/Source.cs
@@ -1,0 +1,17 @@
+using System.Net.Http;
+
+namespace System.Net.Http
+{
+	public class HttpResponseMessage
+	{
+		public string ReasonPhrase { get; set; }
+	}
+}
+
+class Foo
+{
+	public void Method(HttpResponseMessage response)
+	{
+		response.ReasonPhrase = "foo";
+	}
+}

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Diagnostics.xml
@@ -3,4 +3,7 @@
 	<diagnostic>
 		<location>Test0.cs: (15,3-31)</location>
 	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (16,3-37)</location>
+	</diagnostic>
 </diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Diagnostics.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG2007" message="Do not use custom values for the Reason Phrase portion of a HTTP response." severity="Warning">
+	<diagnostic>
+		<location>Test0.cs: (15,3-31)</location>
+	</diagnostic>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
@@ -13,6 +13,8 @@ class Foo
 	public void Method(IHttpResponseFeature feature)
 	{
 		feature.ReasonPhrase = "foo";
+		feature.ReasonPhrase += "suffixed";
+
 		Log(feature.ReasonPhrase);
 	}
 

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
@@ -3,9 +3,9 @@ using Microsoft.AspNetCore.Http.Features;
 namespace Microsoft.AspNetCore.Http.Features
 {
 	public interface IHttpResponseFeature
-    {
+	{
 		string ReasonPhrase { get; set; }
-    }
+	}
 }
 
 class Foo

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
@@ -13,5 +13,10 @@ class Foo
 	public void Method(IHttpResponseFeature feature)
 	{
 		feature.ReasonPhrase = "foo";
+		Log(feature.ReasonPhrase);
+	}
+
+	void Log(string value)
+	{
 	}
 }

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/IHttpResponseFeature/Source.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+	public interface IHttpResponseFeature
+    {
+		string ReasonPhrase { get; set; }
+    }
+}
+
+class Foo
+{
+	public void Method(IHttpResponseFeature feature)
+	{
+		feature.ReasonPhrase = "foo";
+	}
+}

--- a/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/NotWellKnownClass/Source.cs
+++ b/WTG.Analyzers.Test/TestData/HttpReasonPhraseAnalyzer/NotWellKnownClass/Source.cs
@@ -1,0 +1,10 @@
+class Foo
+{
+	public string ReasonPhrase { get; set; }
+
+	public void Method()
+	{
+		ReasonPhrase = "foo";
+		this.ReasonPhrase = "bar";
+	}
+}

--- a/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
@@ -43,11 +43,6 @@ namespace WTG.Analyzers
 
 			var assignment = (AssignmentExpressionSyntax)context.Node;
 
-			if (!assignment.OperatorToken.IsKind(SyntaxKind.EqualsToken))
-			{
-				return;
-			}
-
 			if (!assignment.Left.IsKind(SyntaxKind.SimpleMemberAccessExpression))
 			{
 				return;

--- a/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
@@ -31,7 +31,8 @@ namespace WTG.Analyzers
 
 			context.RegisterSyntaxNodeAction(
 				c => Analyze(c, cache),
-				SyntaxKind.SimpleAssignmentExpression);
+				SyntaxKind.SimpleAssignmentExpression,
+				SyntaxKind.AddAssignmentExpression);
 		}
 
 		static void Analyze(SyntaxNodeAnalysisContext context, FileDetailCache cache)

--- a/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/HttpReasonPhrase/HttpReasonPhraseAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using WTG.Analyzers.Analyzers.BooleanLiteral;
+using WTG.Analyzers.Utils;
+
+namespace WTG.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed partial class HttpReasonPhraseAnalyzer : DiagnosticAnalyzer
+	{
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+			Rules.ForbidCustomHttpReasonPhraseValuesRule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.RegisterCompilationStartAction(CompilationStart);
+		}
+
+		void CompilationStart(CompilationStartAnalysisContext context)
+		{
+			var cache = new FileDetailCache();
+
+			context.RegisterSyntaxNodeAction(
+				c => Analyze(c, cache),
+				SyntaxKind.InvocationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context, FileDetailCache cache)
+		{
+			if (cache.IsGenerated(context.SemanticModel.SyntaxTree, context.CancellationToken))
+			{
+				return;
+			}
+
+			var invocation = (InvocationExpressionSyntax)context.Node;
+
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					Rules.ForbidCustomHttpReasonPhraseValuesRule,
+					invocation.GetLocation()));
+		}
+	}
+}

--- a/WTG.Analyzers/Rules/Rules.g.cs
+++ b/WTG.Analyzers/Rules/Rules.g.cs
@@ -33,6 +33,7 @@ namespace WTG.Analyzers
 		public const string DoNotUseCodeContractsDiagnosticID = "WTG2004";
 		public const string UseCorrectEmitOverloadDiagnosticID = "WTG2005";
 		public const string ForbidCompiledInStaticRegexMethodsDiagnosticID = "WTG2006";
+		public const string ForbidCustomHttpReasonPhraseValuesDiagnosticID = "WTG2007";
 		public const string RemovedOrphanedSuppressionsDiagnosticID = "WTG3001";
 		public const string PreferDirectMemberAccessOverLinqDiagnosticID = "WTG3002";
 		public const string PreferDirectMemberAccessOverLinqInAnExpressionDiagnosticID = "WTG3003";
@@ -324,6 +325,15 @@ namespace WTG.Analyzers
 			DiagnosticSeverity.Warning,
 			isEnabledByDefault: true,
 			description: "The static methods on Regex will discard the regex object, largely negating the benifits of the Compiled option and leaving you with just the increased costs.");
+
+		public static readonly DiagnosticDescriptor ForbidCustomHttpReasonPhraseValuesRule = new DiagnosticDescriptor(
+			ForbidCustomHttpReasonPhraseValuesDiagnosticID,
+			"Do not set custom values for the HTTP Reason Phrase.",
+			"Do not use custom values for the Reason Phrase portion of a HTTP response..",
+			CorrectnessCategory,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "Custom Reason Phrase values may not be passed from a HTTP/1.1 server to the client due to intermediate proxy software, and has been removed entirely from HTTP/2.");
 
 		public static readonly DiagnosticDescriptor RemovedOrphanedSuppressionsRule = new DiagnosticDescriptor(
 			RemovedOrphanedSuppressionsDiagnosticID,
@@ -750,6 +760,14 @@ namespace WTG.Analyzers
 		public static Diagnostic CreateForbidCompiledInStaticRegexMethodsDiagnostic(Location location)
 		{
 			return Diagnostic.Create(ForbidCompiledInStaticRegexMethodsRule, location);
+		}
+
+		/// <summary>
+		/// Do not use custom values for the Reason Phrase portion of a HTTP response..
+		/// </summary>
+		public static Diagnostic CreateForbidCustomHttpReasonPhraseValuesDiagnostic(Location location)
+		{
+			return Diagnostic.Create(ForbidCustomHttpReasonPhraseValuesRule, location);
 		}
 
 		/// <summary>

--- a/WTG.Analyzers/Rules/Rules.g.cs
+++ b/WTG.Analyzers/Rules/Rules.g.cs
@@ -329,7 +329,7 @@ namespace WTG.Analyzers
 		public static readonly DiagnosticDescriptor ForbidCustomHttpReasonPhraseValuesRule = new DiagnosticDescriptor(
 			ForbidCustomHttpReasonPhraseValuesDiagnosticID,
 			"Do not set custom values for the HTTP Reason Phrase.",
-			"Do not use custom values for the Reason Phrase portion of a HTTP response..",
+			"Do not use custom values for the Reason Phrase portion of a HTTP response.",
 			CorrectnessCategory,
 			DiagnosticSeverity.Warning,
 			isEnabledByDefault: true,
@@ -763,7 +763,7 @@ namespace WTG.Analyzers
 		}
 
 		/// <summary>
-		/// Do not use custom values for the Reason Phrase portion of a HTTP response..
+		/// Do not use custom values for the Reason Phrase portion of a HTTP response.
 		/// </summary>
 		public static Diagnostic CreateForbidCustomHttpReasonPhraseValuesDiagnostic(Location location)
 		{

--- a/WTG.Analyzers/Rules/Rules.xml
+++ b/WTG.Analyzers/Rules/Rules.xml
@@ -139,6 +139,11 @@
 			<message>Do not use the Compiled option when calling static methods on Regex.</message>
 			<description>The static methods on Regex will discard the regex object, largely negating the benifits of the Compiled option and leaving you with just the increased costs.</description>
 		</rule>
+		<rule id="7" name="ForbidCustomHttpReasonPhraseValues" severity="Warning">
+			<title>Do not set custom values for the HTTP Reason Phrase.</title>
+			<message>Do not use custom values for the Reason Phrase portion of a HTTP response.</message>
+			<description>Custom Reason Phrase values may not be passed from a HTTP/1.1 server to the client due to intermediate proxy software, and has been removed entirely from HTTP/2.</description>
+		</rule>
 	</category>
 	<category name="Decruftification" id="3000">
 		<rule id="1" name="RemovedOrphanedSuppressions" severity="Info">


### PR DESCRIPTION
The HTTP ReasonPhrase value is a standard human-readable field that accompanies the status code with a reason for it, e.g. 

```plain
HTTP/1.1 200 OK
```

or

```plain
HTTP/1.1 405 Method Not Allowed
```

This can be customised by the server, e.g.:

```plain
HTTP/1.1 200 I'm A Little Teapot Short And Stout
```

Unfortunately there is no guarantee in HTTP/1.0 and HTTP/1.1 that intermediate proxy server will preserve these customised values all the way between the server and client.

Furthermore, in HTTP/2, the ReasonPhrase field has been dropped entirely, leaving only the status code: https://github.com/http2/http2-spec/issues/202

As a part of WI00294611, this PR adds a new analyzer to detect when people set a custom value on [`HttpResponseMessage`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.reasonphrase) (for ASP.NET Web API / Web API 2) or [`IHttpResponseFeature`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.features.ihttpresponsefeature.reasonphrase?view=aspnetcore-3.1) (for ASP.NET Core), draw their attention to the problem, and stop them from doing so at compile-time, well before it has an opportunity to slip through code review.