### PR TITLE
WTG2007 should not trigger in an expression as it will cause CS0853

### DIFF
--- a/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentInAnExpressionTree/Source.cs
+++ b/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentInAnExpressionTree/Source.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq.Expressions;
+
+public class Bob
+{
+	public static void Method()
+	{
+		Baz(b => b.Bar(true, false));
+
+		Baz(b => b.Bar(true,
+			false));
+	}
+
+	public void Bar(bool thing1, bool thing2)
+	{
+	}
+
+	public static void Baz(Expression<Action<Bob>> expr) { }
+}

--- a/WTG.Analyzers/Analyzers/BooleanLiteral/BooleanLiteralAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/BooleanLiteral/BooleanLiteralAnalyzer.cs
@@ -73,6 +73,12 @@ namespace WTG.Analyzers
 				return;
 			}
 
+			if (ExpressionHelper.IsContainedInExpressionTree(context.SemanticModel, expression, context.CancellationToken))
+			{
+				// Avoid error CS0853: An expression tree may not contain a named argument specification.
+				return;
+			}
+
 			var argumentSymbol = argumentList.TryFindCorrespondingParameterSymbol(context.SemanticModel, index, context.CancellationToken);
 
 			if (argumentSymbol is null || argumentSymbol.IsParams || argumentSymbol.Type.SpecialType == SpecialType.System_Object || argumentSymbol.OriginalDefinition.Type.TypeKind == TypeKind.TypeParameter)


### PR DESCRIPTION
> CS0853: An expression tree may not contain a named argument specification.

Whoopsie!