### PR TITLE
Suppress BooleanLiteralAnalyzer on C# versions prior to 4.0

### DIFF
--- a/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentPriorToCSharp4/Diagnostics.xml
+++ b/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentPriorToCSharp4/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG1018" message="Boolean literals as method arguments should be passed as named arguments." severity="Info">
+	<languageVersion>3.0</languageVersion>
+</diagnostics>

--- a/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentPriorToCSharp4/Source.cs
+++ b/WTG.Analyzers.Test/TestData/BooleanLiteralAnalyzer/UnnamedMethodArgumentPriorToCSharp4/Source.cs
@@ -1,0 +1,14 @@
+public static class Bob
+{
+	public static void Method()
+	{
+		Bar(true, false);
+
+		Bar(true,
+			false);
+	}
+
+	public static void Bar(bool thing1, bool thing2)
+	{
+	}
+}

--- a/WTG.Analyzers/Analyzers/BooleanLiteral/BooleanLiteralAnalyzer.cs
+++ b/WTG.Analyzers/Analyzers/BooleanLiteral/BooleanLiteralAnalyzer.cs
@@ -22,6 +22,11 @@ namespace WTG.Analyzers
 
 		void CompilationStart(CompilationStartAnalysisContext context)
 		{
+			if (!context.Compilation.IsCSharpVersionOrGreater(LanguageVersion.CSharp4))
+			{
+				return;
+			}
+
 			var cache = new FileDetailCache();
 
 			context.RegisterSyntaxNodeAction(


### PR DESCRIPTION
Named arguments were only introduced in C# 4.0.

Fixes #131.