### PR TITLE
Removed the 'embed target framework in assembly name' hack.

### DIFF
--- a/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
+++ b/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
@@ -4,7 +4,6 @@
     <AssemblyTitle>WTG Analyzers Test</AssemblyTitle>
     <TargetFrameworks>net46;net5.0</TargetFrameworks>
     <OutputPath>..\bin</OutputPath>
-    <AssemblyName>$(AssemblyName)-$(TargetFramework)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="TestData\**\*.cs" />

--- a/WTG.Analyzers.TestFramework.Test/WTG.Analyzers.TestFramework.Test.csproj
+++ b/WTG.Analyzers.TestFramework.Test/WTG.Analyzers.TestFramework.Test.csproj
@@ -4,7 +4,6 @@
     <AssemblyTitle>WTG Analyzers Test Framework Test</AssemblyTitle>
     <TargetFrameworks>net46;net5.0</TargetFrameworks>
     <OutputPath>..\bin</OutputPath>
-    <AssemblyName>$(AssemblyName)-$(TargetFramework)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">

--- a/WTG.Analyzers.Utils.Test/WTG.Analyzers.Utils.Test.csproj
+++ b/WTG.Analyzers.Utils.Test/WTG.Analyzers.Utils.Test.csproj
@@ -4,7 +4,6 @@
     <AssemblyTitle>WTG Analyzers Utils Test</AssemblyTitle>
     <TargetFrameworks>net46;net5.0</TargetFrameworks>
     <OutputPath>..\bin</OutputPath>
-    <AssemblyName>$(AssemblyName)-$(TargetFramework)</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">


### PR DESCRIPTION
We don't need it now that we use github workflows rather than AppVeyor, and it causes issues with package management.