### PR TITLE
Update packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -112,6 +112,10 @@ csharp_space_between_square_brackets = false
 dotnet_diagnostic.CA1508.severity = none
 
 # XML-based project files
+
+# RS1025: Configure generated code analysis - suppressed until we can decide how we want to handle it (wrt FileDetailCache).
+dotnet_diagnostic.RS1025.severity = none
+
 [*.{csproj,props,targets,ruleset}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Build on ${{ matrix.os }} - ${{ matrix.configuration }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
         configuration: [ Debug, Release ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,9 +34,9 @@ jobs:
     - name: Build NuGet Package
       run: dotnet pack src --configuration ${{ matrix.configuration }} --no-build -p:CommitID=${{ github.sha }}
 
-    - name: Run Tests (net46)
+    - name: Run Tests (net472)
       if: matrix.configuration == 'Debug' && matrix.os == 'windows-latest'
-      run: dotnet test src --no-build --framework net46
+      run: dotnet test src --no-build --framework net472
 
     - name: Run Tests (net6.0)
       if: matrix.configuration == 'Debug'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       - and the major/minor/build versions should match the NuGet package version (NuGet is x.y.z only)
       - Revision should be incremented whenever you want to publish a new version.
       -->
-    <ShortVersion Condition=" '$(TagVersion)' == '' ">3.0.0</ShortVersion>
+    <ShortVersion Condition=" '$(TagVersion)' == '' ">3.3.0</ShortVersion>
     <ShortVersion Condition=" '$(TagVersion)' != '' ">$(TagVersion.Split('-', 2)[0])</ShortVersion>
     <VersionSuffix Condition=" '$(TagVersion)' != '' ">$(TagVersion.Substring($(ShortVersion.Length)))</VersionSuffix>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       - and the major/minor/build versions should match the NuGet package version (NuGet is x.y.z only)
       - Revision should be incremented whenever you want to publish a new version.
       -->
-    <ShortVersion Condition=" '$(TagVersion)' == '' ">3.3.0</ShortVersion>
+    <ShortVersion Condition=" '$(TagVersion)' == '' ">3.3.1</ShortVersion>
     <ShortVersion Condition=" '$(TagVersion)' != '' ">$(TagVersion.Split('-', 2)[0])</ShortVersion>
     <VersionSuffix Condition=" '$(TagVersion)' != '' ">$(TagVersion.Substring($(ShortVersion.Length)))</VersionSuffix>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
       - and the major/minor/build versions should match the NuGet package version (NuGet is x.y.z only)
       - Revision should be incremented whenever you want to publish a new version.
       -->
-    <ShortVersion Condition=" '$(TagVersion)' == '' ">2.10.0</ShortVersion>
+    <ShortVersion Condition=" '$(TagVersion)' == '' ">3.0.0</ShortVersion>
     <ShortVersion Condition=" '$(TagVersion)' != '' ">$(TagVersion.Split('-', 2)[0])</ShortVersion>
     <VersionSuffix Condition=" '$(TagVersion)' != '' ">$(TagVersion.Substring($(ShortVersion.Length)))</VersionSuffix>
 

--- a/WTG.Analyzers.TestFramework.nuspec
+++ b/WTG.Analyzers.TestFramework.nuspec
@@ -12,14 +12,12 @@
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<developmentDependency>true</developmentDependency>
 		<dependencies>
-			<group targetFramework=".NETFramework4.6" />
 			<group targetFramework=".NETStandard2.0" />
 		</dependencies>
 	</metadata>
 
 	<files>
 		<!-- Binaries -->
-		<file src="bin\net46\WTG.Analyzers.TestFramework.dll" target="lib\net46" />
 		<file src="bin\netstandard2.0\WTG.Analyzers.TestFramework.dll" target="lib\netstandard2.0" />
 
 		<!-- Other -->

--- a/WTG.Analyzers.Utils.nuspec
+++ b/WTG.Analyzers.Utils.nuspec
@@ -12,7 +12,7 @@
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.0.0" />
+				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.0.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/WTG.Analyzers.Utils.nuspec
+++ b/WTG.Analyzers.Utils.nuspec
@@ -11,7 +11,7 @@
 		<copyright>$copyright$</copyright>
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<dependencies>
-			<group targetFramework=".NETStandard1.3">
+			<group targetFramework=".NETStandard2.0">
 				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.0.0" />
 			</group>
 		</dependencies>
@@ -19,7 +19,7 @@
 
 	<files>
 		<!-- Binaries -->
-		<file src="bin\netstandard1.3\WTG.Analyzers.Utils.dll" target="lib\netstandard1.3" />
+		<file src="bin\netstandard2.0\WTG.Analyzers.Utils.dll" target="lib\netstandard2.0" />
 
 		<!-- Other -->
 		<file src="LICENSE.md" target="" />

--- a/WTG.Analyzers.Utils.nuspec
+++ b/WTG.Analyzers.Utils.nuspec
@@ -12,7 +12,7 @@
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.3.0" />
+				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.3.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/WTG.Analyzers.Utils.nuspec
+++ b/WTG.Analyzers.Utils.nuspec
@@ -12,7 +12,7 @@
 		<repository type="git" url="https://github.com/WiseTechGlobal/WTG.Analyzers" commit="$commitid$" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.0.0" />
+				<dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.3.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/WTG.Analyzers.nuspec
+++ b/WTG.Analyzers.nuspec
@@ -15,8 +15,8 @@
 
 	<files>
 		<!-- Binaries -->
-		<file src="bin\netstandard1.3\WTG.Analyzers.dll" target="analyzers\dotnet\cs" />
-		<file src="bin\netstandard1.3\WTG.Analyzers.Utils.dll" target="analyzers\dotnet\cs" />
+		<file src="bin\netstandard2.0\WTG.Analyzers.dll" target="analyzers\dotnet\cs" />
+		<file src="bin\netstandard2.0\WTG.Analyzers.Utils.dll" target="analyzers\dotnet\cs" />
 
 		<!-- MSBuild Properties and Targets -->
 		<file src="src\WTG.Analyzers\build\WTG.Analyzers.props" target="build\" />

--- a/src/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
+++ b/src/WTG.Analyzers.Test/WTG.Analyzers.Test.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Test</AssemblyTitle>
-    <TargetFrameworks>net46;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/src/WTG.Analyzers.TestFramework.Test/CodeFixerTest.cs
+++ b/src/WTG.Analyzers.TestFramework.Test/CodeFixerTest.cs
@@ -49,6 +49,7 @@ namespace WTG.Analyzers.Framework.Test
 
 			public override void Initialize(AnalysisContext context)
 			{
+				context.EnableConcurrentExecution();
 				context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
 			}
 

--- a/src/WTG.Analyzers.TestFramework.Test/WTG.Analyzers.TestFramework.Test.csproj
+++ b/src/WTG.Analyzers.TestFramework.Test/WTG.Analyzers.TestFramework.Test.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Test Framework Test</AssemblyTitle>
-    <TargetFrameworks>net46;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/src/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
@@ -219,7 +219,8 @@ namespace WTG.Analyzers.TestFramework
 		{
 			var operations = await codeAction.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
 			var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
-			return solution.GetDocument(document.Id);
+			return solution.GetDocument(document.Id)
+				?? throw new NotSupportedException("Analyzer attempted to remove the document being fixed, this is not currently a supported situation.");
 		}
 
 		static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)

--- a/src/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/DiagnosticUtils.cs
@@ -38,7 +38,7 @@ namespace WTG.Analyzers.TestFramework
 						for (var i = 0; i < documents.Length; i++)
 						{
 							var document = documents[i];
-							if (project.GetDocument(diag.Location.SourceTree).Id == document.Id)
+							if (project.GetDocument(diag.Location.SourceTree)?.Id == document.Id)
 							{
 								diagnostics.Add(diag);
 							}

--- a/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -65,7 +65,7 @@ namespace WTG.Analyzers.TestFramework
 		{
 			var newProject = AddProject(project.Solution, assemblyName, sources);
 
-			return newProject.Solution.GetProject(project.Id)
+			return newProject.Solution.GetProject(project.Id)!
 				.WithProjectReferences(project.ProjectReferences.Concat(new[] { new ProjectReference(newProject.Id) }));
 		}
 
@@ -75,7 +75,7 @@ namespace WTG.Analyzers.TestFramework
 
 			var solution = currentSolution.AddProject(projectId, assemblyName, assemblyName, LanguageNames.CSharp);
 
-			var project = solution.GetProject(projectId)
+			var project = solution.GetProject(projectId)!
 				.AddMetadataReferences(MetadataReferences);
 
 			var compilationOptions = (CSharpCompilationOptions)project.CompilationOptions;
@@ -96,7 +96,7 @@ namespace WTG.Analyzers.TestFramework
 					SourceText.From(sources[i]));
 			}
 
-			return solution.GetProject(projectId);
+			return solution.GetProject(projectId)!;
 		}
 
 		static string GetFileName(int count)

--- a/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -19,10 +19,9 @@ namespace WTG.Analyzers.TestFramework
 			var document = CreateDocument(dataSet.Source);
 			var project = document.Project;
 
-			project = project.WithParseOptions(
-				((CSharpParseOptions)project.ParseOptions).WithLanguageVersion(dataSet.LanguageVersion));
+			project = project.WithParseOptions(GetParseOptions(project).WithLanguageVersion(dataSet.LanguageVersion));
 
-			return project.GetDocument(document.Id);
+			return project.GetDocument(document.Id)!;
 		}
 
 		public static Document CreateDocument(string source)
@@ -78,8 +77,7 @@ namespace WTG.Analyzers.TestFramework
 			var project = solution.GetProject(projectId)!
 				.AddMetadataReferences(MetadataReferences);
 
-			var compilationOptions = (CSharpCompilationOptions)project.CompilationOptions;
-			compilationOptions = compilationOptions
+			var compilationOptions = GetCompilationOptions(project)
 				.WithAllowUnsafe(enabled: true)
 				.WithOutputKind(OutputKind.DynamicallyLinkedLibrary);
 			project = project.WithCompilationOptions(compilationOptions);
@@ -103,6 +101,9 @@ namespace WTG.Analyzers.TestFramework
 		{
 			return DefaultFilePathPrefix + count + "." + CSharpDefaultFileExt;
 		}
+
+		static CSharpParseOptions GetParseOptions(Project project) => (CSharpParseOptions)project.ParseOptions!;
+		static CSharpCompilationOptions GetCompilationOptions(Project project) => (CSharpCompilationOptions)project.CompilationOptions!;
 
 		const string DefaultFilePathPrefix = "Test";
 		const string CSharpDefaultFileExt = "cs";

--- a/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
+++ b/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Test Framework</AssemblyTitle>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputPath>..\..\bin</OutputPath>
     <NuspecFile>..\..\WTG.Analyzers.TestFramework.nuspec</NuspecFile>
     <Nullable>enable</Nullable>

--- a/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
+++ b/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
+++ b/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
+++ b/src/WTG.Analyzers.TestFramework/WTG.Analyzers.TestFramework.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers.Utils.Test/DocumentBatchedFixAllProviderTest.cs
+++ b/src/WTG.Analyzers.Utils.Test/DocumentBatchedFixAllProviderTest.cs
@@ -115,6 +115,7 @@ namespace WTG.Analyzers.Utils.Test
 
 			public override ImmutableArray<string> FixableDiagnosticIds => throw new NotImplementedException();
 			public override Task RegisterCodeFixesAsync(CodeFixContext context) => throw new NotImplementedException();
+			public override FixAllProvider GetFixAllProvider() => null;
 		}
 
 		sealed class TestProvider : FixAllContext.DiagnosticProvider

--- a/src/WTG.Analyzers.Utils.Test/WTG.Analyzers.Utils.Test.csproj
+++ b/src/WTG.Analyzers.Utils.Test/WTG.Analyzers.Utils.Test.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Utils Test</AssemblyTitle>
-    <TargetFrameworks>net46;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/src/WTG.Analyzers.Utils/DocumentBatchedFixAllProvider.cs
+++ b/src/WTG.Analyzers.Utils/DocumentBatchedFixAllProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -117,7 +118,8 @@ namespace WTG.Analyzers.Utils
 		{
 			foreach (var diagnostic in diagnostics)
 			{
-				var document = project.GetDocument(diagnostic.Location.SourceTree);
+				var document = project.GetDocument(diagnostic.Location.SourceTree)
+					?? throw new ArgumentException("Diagnostic not from specified project.");
 
 				if (!builder.TryGetValue(document, out var list))
 				{

--- a/src/WTG.Analyzers.Utils/DocumentBatchedFixAllProvider.cs
+++ b/src/WTG.Analyzers.Utils/DocumentBatchedFixAllProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,9 +22,12 @@ namespace WTG.Analyzers.Utils
 			{
 				switch (fixAllContext.Scope)
 				{
-					case FixAllScope.Document: return GetFixForDocumentAsync(fixAllContext);
-					case FixAllScope.Project: return GetFixForProjectAsync(fixAllContext);
-					case FixAllScope.Solution: return GetFixForSolutionAsync(fixAllContext);
+					case FixAllScope.Document:
+						return GetFixForDocumentAsync(fixAllContext);
+					case FixAllScope.Project:
+						return GetFixForProjectAsync(fixAllContext);
+					case FixAllScope.Solution:
+						return GetFixForSolutionAsync(fixAllContext);
 				}
 			}
 
@@ -47,8 +50,12 @@ namespace WTG.Analyzers.Utils
 			{
 				var originalDocument = pair.Key;
 				var documentToFix = solution.GetDocument(originalDocument.Id);
-				var newDocument = await ApplyFixesAsync(originalDocument, documentToFix, pair.Value, cancellationToken).ConfigureAwait(false);
-				solution = newDocument.Project.Solution;
+
+				if (documentToFix != null)
+				{
+					var newDocument = await ApplyFixesAsync(originalDocument, documentToFix, pair.Value, cancellationToken).ConfigureAwait(false);
+					solution = newDocument.Project.Solution;
+				}
 			}
 
 			return solution;

--- a/src/WTG.Analyzers.Utils/SymbolExtensions.cs
+++ b/src/WTG.Analyzers.Utils/SymbolExtensions.cs
@@ -139,7 +139,7 @@ namespace WTG.Analyzers.Utils
 					{
 						var local = decl.FindImplementationForInterfaceMember(member);
 
-						if (local == symbol)
+						if (SymbolEqualityComparer.Default.Equals(local, symbol))
 						{
 							return true;
 						}

--- a/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
+++ b/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
+++ b/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
+++ b/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
@@ -2,10 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers Utils</AssemblyTitle>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputPath>..\..\bin\</OutputPath>
     <NuspecFile>..\..\WTG.Analyzers.Utils.nuspec</NuspecFile>
-    <PackageTargetFallback>portable-net45+win8+wp8+wpa81</PackageTargetFallback>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
+++ b/src/WTG.Analyzers.Utils/WTG.Analyzers.Utils.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.Analyzers/Analyzers/Flags/FlagsAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/Flags/FlagsAnalyzer.cs
@@ -18,6 +18,7 @@ namespace WTG.Analyzers
 
 		public override void Initialize(AnalysisContext context)
 		{
+			context.EnableConcurrentExecution();
 			var cache = new FileDetailCache();
 
 			context.RegisterSyntaxNodeAction(

--- a/src/WTG.Analyzers/Analyzers/Linq/LinqCodeFixProvider.cs
+++ b/src/WTG.Analyzers/Analyzers/Linq/LinqCodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace WTG.Analyzers
 			var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 			var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 			var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-			var model = compilation.GetSemanticModel(tree);
+			var model = compilation!.GetSemanticModel(tree);
 
 			var invoke = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 

--- a/src/WTG.Analyzers/Analyzers/Var/VarAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/Var/VarAnalyzer.cs
@@ -207,10 +207,7 @@ namespace WTG.Analyzers
 			}
 		}
 
-		static bool TypeEquals(ITypeSymbol? x, ITypeSymbol? y)
-		{
-			return x == y || (x != null && x.Equals(y));
-		}
+		static bool TypeEquals(ITypeSymbol? x, ITypeSymbol? y) => ReferenceEquals(x, y) || (x != null && x.Equals(y));
 
 		sealed class Visitor : CSharpSyntaxVisitor<Candidate?>
 		{

--- a/src/WTG.Analyzers/WTG.Analyzers.csproj
+++ b/src/WTG.Analyzers/WTG.Analyzers.csproj
@@ -2,10 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>WTG Analyzers</AssemblyTitle>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputPath>..\..\bin</OutputPath>
     <NuspecFile>..\..\WTG.Analyzers.nuspec</NuspecFile>
-    <PackageTargetFallback>portable-net45+win8+wp8+wpa81</PackageTargetFallback>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Only updated Roslyn as far as 3.3.1, this is because the 3.4 made a few more methods return nullable types and this produces a _lot_ more errors. I'll upgrade to 3.4 separately and at a later time.

closes #149 