### PR TITLE
Fix #163

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NotBoolean/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NotBoolean/Source.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.Contracts;
+
+public static class Bob
+{
+	public static bool? Complex1(bool a) => a ? true : (bool?)null;
+	public static bool? Complex2(bool a) => a ? (bool?)null : true;
+	public static bool? Complex3(bool a) => a ? false : (bool?)null;
+	public static bool? Complex4(bool a) => a ? (bool?)null : false;
+	public static object Complex5(bool a) => a ? true : (object)null;
+	public static object Complex6(bool a) => a ? (object)null : true;
+	public static object Complex7(bool a) => a ? false : (object)null;
+	public static object Complex8(bool a) => a ? (object)null : false;
+}

--- a/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningAnalyzer.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using WTG.Analyzers.Utils;
 
@@ -35,7 +37,7 @@ namespace WTG.Analyzers
 				return;
 			}
 
-			if (CanBeSimplified(context.Node.Parent))
+			if (CanBeSimplified(context.Node, context.SemanticModel, context.CancellationToken))
 			{
 				context.ReportDiagnostic(
 					Rules.CreateAvoidBoolLiteralsInLargerBoolExpressionsDiagnostic(
@@ -43,22 +45,32 @@ namespace WTG.Analyzers
 			}
 		}
 
-		static bool CanBeSimplified(SyntaxNode node)
+		static bool CanBeSimplified(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
 		{
-			switch (node.Kind())
+			switch (node.Parent.Kind())
 			{
 				case SyntaxKind.LogicalAndExpression:
 				case SyntaxKind.LogicalOrExpression:
-				case SyntaxKind.ConditionalExpression:
 				case SyntaxKind.LogicalNotExpression:
 				case SyntaxKind.ParenthesizedExpression:
 				case SyntaxKind.AndAssignmentExpression:
 				case SyntaxKind.OrAssignmentExpression:
 					return true;
 
+				case SyntaxKind.ConditionalExpression:
+					var condition = (ConditionalExpressionSyntax)node.Parent;
+					var expressionToCheck = condition.WhenTrue == node ? condition.WhenFalse : condition.WhenTrue;
+					var result = IsSimpleBooleanExpression(expressionToCheck, semanticModel, cancellationToken);
+					return result;
+
 				default:
 					return false;
 			}
+
+			static bool IsSimpleBooleanExpression(ExpressionSyntax syntax, SemanticModel semanticModel, CancellationToken cancellationToken)
+				=> IsSimpleBooleanType(semanticModel.GetTypeInfo(syntax, cancellationToken).Type);
+
+			static bool IsSimpleBooleanType(ITypeSymbol type) => type.SpecialType == SpecialType.System_Boolean;
 		}
 	}
 }


### PR DESCRIPTION
Fixes warning about boolean literals in conditional expressions if the conditional expression is of a type other than bool, as our proposed code fixes are not valid C#.