### PR TITLE
Extend WTG3011 to cover some string constructors.

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Diagnostics.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3011" message="Mutating the arguments before appending results in the creation of an unnecessary intermediate string." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (10,19-37)</location>
+		<location>Test0.cs: (10,4-38)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (11,19-52)</location>
+		<location>Test0.cs: (11,4-53)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Result.cs
@@ -1,0 +1,14 @@
+using System.Text;
+
+namespace Magic
+{
+	class Bob
+	{
+		void Method(char[] buffer, int start, int length)
+		{
+			var builder = new StringBuilder();
+			builder.Append(buffer);
+			builder.Append(buffer, start, length);
+		}
+	}
+}

--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/CharBuffer/Source.cs
@@ -1,0 +1,14 @@
+using System.Text;
+
+namespace Magic
+{
+	class Bob
+	{
+		void Method(char[] buffer, int start, int length)
+		{
+			var builder = new StringBuilder();
+			builder.Append(new string(buffer));
+			builder.Append(new string(buffer, start, length));
+		}
+	}
+}

--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Diagnostics.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3011" message="Mutating the arguments before appending results in the creation of an unnecessary intermediate string." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (10,19-40)</location>
+		<location>Test0.cs: (10,4-41)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Result.cs
@@ -1,0 +1,13 @@
+using System.Text;
+
+namespace Magic
+{
+	class Bob
+	{
+		void Method(char c, int repeat)
+		{
+			var builder = new StringBuilder();
+			builder.Append(c, repeat);
+		}
+	}
+}

--- a/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/StringBuilderAppendAnalyzer/StringConstructor/RepeatedChar/Source.cs
@@ -1,0 +1,13 @@
+using System.Text;
+
+namespace Magic
+{
+	class Bob
+	{
+		void Method(char c, int repeat)
+		{
+			var builder = new StringBuilder();
+			builder.Append(new string(c, repeat));
+		}
+	}
+}

--- a/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendAnalyzer.cs
@@ -87,6 +87,9 @@ namespace WTG.Analyzers
 					return name == nameof(string.Format)
 						|| name == nameof(string.Substring);
 
+				case SyntaxKind.ObjectCreationExpression:
+					return true;
+
 				default:
 					return false;
 			}
@@ -120,11 +123,28 @@ namespace WTG.Analyzers
 					return true;
 
 				case SyntaxKind.InvocationExpression:
-					var symbol = (IMethodSymbol)semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
+					{
+						var symbol = (IMethodSymbol)semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
 
-					return symbol != null
-						&& symbol.ContainingType.SpecialType == SpecialType.System_String
-						&& (symbol.Name == nameof(string.Format) || symbol.Name == nameof(string.Substring));
+						return symbol != null
+							&& symbol.ContainingType.SpecialType == SpecialType.System_String
+							&& (symbol.Name == nameof(string.Format) || symbol.Name == nameof(string.Substring));
+					}
+
+				case SyntaxKind.ObjectCreationExpression:
+					{
+						var symbol = (IMethodSymbol)semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
+
+						if (symbol != null && symbol.ContainingType.SpecialType == SpecialType.System_String)
+						{
+							var parameters = symbol.Parameters;
+
+							return parameters.Length == 2
+								&& parameters[0].Type.SpecialType == SpecialType.System_Char
+								&& parameters[1].Type.SpecialType == SpecialType.System_Int32;
+						}
+						return false;
+					}
 
 				default:
 					return false;

--- a/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendAnalyzer.cs
@@ -139,9 +139,20 @@ namespace WTG.Analyzers
 						{
 							var parameters = symbol.Parameters;
 
-							return parameters.Length == 2
-								&& parameters[0].Type.SpecialType == SpecialType.System_Char
-								&& parameters[1].Type.SpecialType == SpecialType.System_Int32;
+							switch (parameters.Length)
+							{
+								case 1:
+									return IsCharArray(parameters[0].Type);
+
+								case 2:
+									return parameters[0].Type.SpecialType == SpecialType.System_Char
+										&& parameters[1].Type.SpecialType == SpecialType.System_Int32;
+
+								case 3:
+									return IsCharArray(parameters[0].Type)
+										&& parameters[1].Type.SpecialType == SpecialType.System_Int32
+										&& parameters[2].Type.SpecialType == SpecialType.System_Int32;
+							}
 						}
 						return false;
 					}
@@ -149,6 +160,17 @@ namespace WTG.Analyzers
 				default:
 					return false;
 			}
+		}
+
+		static bool IsCharArray(ITypeSymbol type)
+		{
+			if (type.TypeKind != TypeKind.Array)
+			{
+				return false;
+			}
+
+			var arrayType = (IArrayTypeSymbol)type;
+			return arrayType.IsSZArray && arrayType.ElementType.SpecialType == SpecialType.System_Char;
 		}
 	}
 }

--- a/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendCodeFixProvider.cs
+++ b/src/WTG.Analyzers/Analyzers/StringBuilderAppend/StringBuilderAppendCodeFixProvider.cs
@@ -91,7 +91,7 @@ namespace WTG.Analyzers
 					baseExpression = Invoke(baseExpression, Append, GetSubstringArguments((InvocationExpressionSyntax)valueExpression));
 					break;
 
-				case Category.RepeatedChar:
+				case Category.StringConstructor:
 					baseExpression = Invoke(baseExpression, Append, GetStringConstructorArguments((ObjectCreationExpressionSyntax)valueExpression));
 					break;
 
@@ -138,14 +138,7 @@ namespace WTG.Analyzers
 
 				if (methodSymbol != null && methodSymbol.ContainingType.SpecialType == SpecialType.System_String)
 				{
-					var parameters = methodSymbol.Parameters;
-
-					if (parameters.Length == 2 &&
-						parameters[0].Type.SpecialType == SpecialType.System_Char &&
-						parameters[1].Type.SpecialType == SpecialType.System_Int32)
-					{
-						return Category.RepeatedChar;
-					}
+					return Category.StringConstructor;
 				}
 			}
 
@@ -232,7 +225,7 @@ namespace WTG.Analyzers
 			Substring,
 			StringValue,
 			NonStringValue,
-			RepeatedChar,
+			StringConstructor,
 		}
 	}
 }


### PR DESCRIPTION
Extend WTG3011 to cover the following cases:

```csharp
builder.Append(new string(c, repeat)); // string(char, int)
builder.Append(new string(buffer)); // string(char[])
builder.Append(new string(buffer, start, length)); // string(char[], int, int)
```

The code fixes should rewrite them to:

```csharp
builder.Append(c, repeat); // string(char, int)
builder.Append(buffer); // string(char[])
builder.Append(buffer, start, length); // string(char[], int, int)
```