### PR TITLE
Don't offer to fix value coercion expressions.

### DIFF
--- a/src/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/src/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
@@ -75,17 +77,62 @@ namespace WTG.Analyzers.Test
 
 			Assert.That(actual.Where(filter), IsDiagnostic.EqualTo(data.Diagnostics));
 
-			var fixer = new CodeFixer(analyzer, new TCodeFix())
+			if ((data.Options & SampleDataSetOptions.AllowCodeFixes) != 0)
 			{
-				DiagnosticFilter = filter,
-			};
+				var fixer = new CodeFixer(analyzer, new TCodeFix())
+				{
+					DiagnosticFilter = filter,
+				};
 
-			await fixer.VerifyFixAsync(document, data.Result).ConfigureAwait(false);
+				await fixer.VerifyFixAsync(document, data.Result).ConfigureAwait(false);
+			}
+			else
+			{
+				var codeFix = new TCodeFix();
+				var actions = new List<Tuple<Diagnostic, CodeAction>>();
+
+				foreach (Diagnostic diagnostic in actual)
+				{
+					if (!codeFix.FixableDiagnosticIds.Contains(diagnostic.Id))
+					{
+						continue;
+					}
+
+					await CodeFixUtils.CollectCodeActions(codeFix, document, diagnostic, actions).ConfigureAwait(false);
+				}
+
+				if (actions.Count > 0)
+				{
+					var builder = new StringBuilder()
+						.AppendLine("The diagnostics should not have offered any code fix actions, but instead found:");
+
+					foreach (var (diagnostic, action) in actions)
+					{
+						builder
+							.Append("* ")
+							.Append(diagnostic.Id)
+							.Append(' ');
+
+						AppendLocation(builder, diagnostic.Location);
+
+						builder
+							.Append(": ")
+							.AppendLine(action.Title);
+					}
+
+					Assert.Fail(builder.ToString());
+				}
+			}
 		}
 
 		[Test]
 		public async Task BulkUpdate([ValueSource(nameof(Samples))] SampleDataSet data)
 		{
+			if ((data.Options & SampleDataSetOptions.AllowCodeFixes) == 0)
+			{
+				return;
+			}
+
 			var analyzer = new TAnalyzer();
 			var document = ModelUtils.CreateDocument(data);
 
@@ -103,6 +150,36 @@ namespace WTG.Analyzers.Test
 
 		const string TestDataPrefix = "WTG.Analyzers.Test.TestData.";
 		static IEnumerable<SampleDataSet> Samples => SampleDataSet.GetSamples(typeof(AnalyzerAndCodeFixTest<,>).GetTypeInfo().Assembly, TestDataPrefix + typeof(TAnalyzer).Name + ".");
+
+		static void AppendLocation(StringBuilder builder, Location location)
+		{
+			var span = location.GetLineSpan();
+			var start = span.StartLinePosition;
+			var end = span.EndLinePosition;
+
+			builder
+				.Append('(')
+				.Append(start.Line)
+				.Append(',')
+				.Append(start.Character);
+
+			if (start.Line != end.Line)
+			{
+				builder
+					.Append(")-(")
+					.Append(end.Line)
+					.Append(',')
+					.Append(end.Character);
+			}
+			else if (start.Character != end.Character)
+			{
+				builder
+					.Append('-')
+					.Append(end.Character);
+			}
+
+			builder.Append(')');
+		}
 
 		#endregion
 	}

--- a/src/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
+++ b/src/WTG.Analyzers.Test/AnalyzerAndCodeFixTest.cs
@@ -126,13 +126,8 @@ namespace WTG.Analyzers.Test
 		}
 
 		[Test]
-		public async Task BulkUpdate([ValueSource(nameof(Samples))] SampleDataSet data)
+		public async Task BulkUpdate([ValueSource(nameof(FixableSamples))] SampleDataSet data)
 		{
-			if ((data.Options & SampleDataSetOptions.AllowCodeFixes) == 0)
-			{
-				return;
-			}
-
 			var analyzer = new TAnalyzer();
 			var document = ModelUtils.CreateDocument(data);
 
@@ -150,6 +145,7 @@ namespace WTG.Analyzers.Test
 
 		const string TestDataPrefix = "WTG.Analyzers.Test.TestData.";
 		static IEnumerable<SampleDataSet> Samples => SampleDataSet.GetSamples(typeof(AnalyzerAndCodeFixTest<,>).GetTypeInfo().Assembly, TestDataPrefix + typeof(TAnalyzer).Name + ".");
+		static IEnumerable<SampleDataSet> FixableSamples => Samples.Where(x => (x.Options & SampleDataSetOptions.AllowCodeFixes) != 0);
 
 		static void AppendLocation(StringBuilder builder, Location location)
 		{

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NoAutoFix/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NoAutoFix/Diagnostics.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3012" message="Boolean expression can be simplified." severity="Info">
+	<allowCodeFixes>false</allowCodeFixes>
+	<diagnostic>
+		<location>Test0.cs: (5,42-47)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (6,42-46)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NoAutoFix/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/NoAutoFix/Source.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics.Contracts;
+
+public static class Bob
+{
+	public static bool Not1(bool a) => a && false;
+	public static bool Not2(bool a) => a || true;
+}

--- a/src/WTG.Analyzers.TestFramework/Helpers/CodeFixUtils.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/CodeFixUtils.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace WTG.Analyzers.TestFramework
+{
+	public static class CodeFixUtils
+	{
+		public static async Task CollectCodeActions(CodeFixProvider provider, Document document, Diagnostic diagnostic, ICollection<Tuple<Diagnostic, CodeAction>> actions)
+		{
+			if (actions == null)
+			{
+				throw new ArgumentNullException(nameof(actions));
+			}
+
+			var context = new CodeFixContext(document, diagnostic, (a, b) => actions.Add(Tuple.Create(diagnostic, a)), CancellationToken.None);
+			await provider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+		}
+	}
+}

--- a/src/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/CodeFixer.cs
@@ -190,8 +190,7 @@ namespace WTG.Analyzers.TestFramework
 			{
 				if (IsFixable(diagnostic))
 				{
-					var context = new CodeFixContext(document, diagnostic, (a, b) => actions.Add(Tuple.Create(diagnostic, a)), CancellationToken.None);
-					await CodeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+					await CodeFixUtils.CollectCodeActions(CodeFixProvider, document, diagnostic, actions).ConfigureAwait(false);
 				}
 			}
 

--- a/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
+++ b/src/WTG.Analyzers.TestFramework/Helpers/ModelUtils.cs
@@ -16,7 +16,7 @@ namespace WTG.Analyzers.TestFramework
 	{
 		public static Document CreateDocument(SampleDataSet dataSet)
 		{
-			var document = CreateDocument(dataSet.Source, dataSet.OmitAssemblyReferences);
+			var document = CreateDocument(dataSet.Source, (dataSet.Options & SampleDataSetOptions.OmitAssemblyReferences) != 0);
 			var project = document.Project;
 
 			project = project.WithParseOptions(GetParseOptions(project).WithLanguageVersion(dataSet.LanguageVersion));

--- a/src/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
+++ b/src/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
@@ -115,9 +115,14 @@ namespace WTG.Analyzers.TestFramework
 
 				var options = SampleDataSetOptions.None;
 
-				if (ToBoolean(root.Element("omitAssemblyReferences")?.Value))
+				if (ToBoolean(root.Element("omitAssemblyReferences")?.Value, false))
 				{
 					options |= SampleDataSetOptions.OmitAssemblyReferences;
+				}
+
+				if (ToBoolean(root.Element("allowCodeFixes")?.Value, true))
+				{
+					options |= SampleDataSetOptions.AllowCodeFixes;
 				}
 
 				return new SampleDataSet(
@@ -137,7 +142,7 @@ namespace WTG.Analyzers.TestFramework
 					LanguageVersion.Default,
 					source,
 					result,
-					SampleDataSetOptions.None,
+					SampleDataSetOptions.AllowCodeFixes,
 					ImmutableArray<DiagnosticResult>.Empty,
 					ImmutableHashSet<string>.Empty,
 					ImmutableArray<OSPlatform>.Empty);
@@ -146,8 +151,8 @@ namespace WTG.Analyzers.TestFramework
 			static LanguageVersion ToLanguageVersion(string? ver)
 				=> LanguageVersionFacts.TryParse(ver, out var tmp) ? tmp : LanguageVersion.Default;
 
-			static bool ToBoolean(string? text)
-				=> bool.TryParse(text, out var tmp) && tmp;
+			static bool ToBoolean(string? value, bool defaultValue)
+				=> bool.TryParse(value, out var result) ? result : defaultValue;
 		}
 
 		static string? LoadResource(Assembly assembly, string name)

--- a/src/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
+++ b/src/WTG.Analyzers.TestFramework/TestData/SampleDataSet.cs
@@ -15,26 +15,26 @@ namespace WTG.Analyzers.TestFramework
 {
 	public sealed class SampleDataSet
 	{
-		SampleDataSet(string name, LanguageVersion languageVersion, string source, string result, ImmutableArray<DiagnosticResult> diagnostics, ImmutableHashSet<string> suppressedIds, ImmutableArray<OSPlatform> platforms, bool omitAssemblyReferences)
+		SampleDataSet(string name, LanguageVersion languageVersion, string source, string result, SampleDataSetOptions options, ImmutableArray<DiagnosticResult> diagnostics, ImmutableHashSet<string> suppressedIds, ImmutableArray<OSPlatform> platforms)
 		{
 			Name = name;
 			LanguageVersion = languageVersion;
 			Source = source;
 			Result = result;
+			Options = options;
 			Diagnostics = diagnostics;
 			SuppressedIds = suppressedIds;
 			Platforms = platforms;
-			OmitAssemblyReferences = omitAssemblyReferences;
 		}
 
 		public string Name { get; }
 		public LanguageVersion LanguageVersion { get; }
 		public string Source { get; }
 		public string Result { get; }
+		public SampleDataSetOptions Options { get; }
 		public ImmutableArray<DiagnosticResult> Diagnostics { get; }
 		public ImmutableHashSet<string> SuppressedIds { get; }
 		public ImmutableArray<OSPlatform> Platforms { get; }
-		public bool OmitAssemblyReferences { get; }
 
 		public override string ToString() => Name;
 
@@ -112,17 +112,23 @@ namespace WTG.Analyzers.TestFramework
 				var suppressedIds = root.Elements("suppressId").Select(x => x.Value).ToImmutableHashSet();
 				var platforms = root.Elements("platform").Select(x => OSPlatform.Create(x.Value)).ToImmutableArray();
 				var languageVersion = ToLanguageVersion(root.Element("languageVersion")?.Value);
-				var omitAssemblyReferences = ToBoolean(root.Element("omitAssemblyReferences")?.Value);
+
+				var options = SampleDataSetOptions.None;
+
+				if (ToBoolean(root.Element("omitAssemblyReferences")?.Value))
+				{
+					options |= SampleDataSetOptions.OmitAssemblyReferences;
+				}
 
 				return new SampleDataSet(
 					name,
 					languageVersion,
 					source,
 					result,
+					options,
 					diagnostics,
 					suppressedIds,
-					platforms,
-					omitAssemblyReferences);
+					platforms);
 			}
 			else
 			{
@@ -131,10 +137,10 @@ namespace WTG.Analyzers.TestFramework
 					LanguageVersion.Default,
 					source,
 					result,
+					SampleDataSetOptions.None,
 					ImmutableArray<DiagnosticResult>.Empty,
 					ImmutableHashSet<string>.Empty,
-					ImmutableArray<OSPlatform>.Empty,
-					omitAssemblyReferences: false);
+					ImmutableArray<OSPlatform>.Empty);
 			}
 
 			static LanguageVersion ToLanguageVersion(string? ver)

--- a/src/WTG.Analyzers.TestFramework/TestData/SampleDataSetOptions.cs
+++ b/src/WTG.Analyzers.TestFramework/TestData/SampleDataSetOptions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace WTG.Analyzers.TestFramework
+{
+	[Flags]
+	public enum SampleDataSetOptions
+	{
+		None = 0,
+		OmitAssemblyReferences = 1 << 0,
+	}
+}

--- a/src/WTG.Analyzers.TestFramework/TestData/SampleDataSetOptions.cs
+++ b/src/WTG.Analyzers.TestFramework/TestData/SampleDataSetOptions.cs
@@ -7,5 +7,6 @@ namespace WTG.Analyzers.TestFramework
 	{
 		None = 0,
 		OmitAssemblyReferences = 1 << 0,
+		AllowCodeFixes = 1 << 1,
 	}
 }


### PR DESCRIPTION
Fixes #168 

Don't offer to fix value coercion expressions, eg.

```csharp
x || true
x && false
```
