### PR TITLE
Try to avoid CS0201 when collapsing away and/or assignments.

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/AndOrAssignment/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/AndOrAssignment/Diagnostics.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics id="WTG3012" message="Boolean expression can be simplified." severity="Info">
-	<suppressId>CS0201</suppressId>
 	<diagnostic>
 		<location>Test0.cs: (7,8-12)</location>
 	</diagnostic>

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/AndOrAssignment/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/AndOrAssignment/Result.cs
@@ -9,12 +9,10 @@ public static class Bob
 	}
 	public static bool Method2(bool a)
 	{
-		a;
 		return a;
 	}
 	public static bool Method3(bool a)
 	{
-		a;
 		return a;
 	}
 	public static bool Method4(bool a)

--- a/src/WTG.Analyzers.Utils.Test/ExpressionRemoverTest.cs
+++ b/src/WTG.Analyzers.Utils.Test/ExpressionRemoverTest.cs
@@ -237,6 +237,33 @@ namespace WTG.Analyzers.Utils.Test
 			Assert.That(actual, Is.EqualTo(Expected));
 		}
 
+		[Test]
+		public void RemovedStatementComments()
+		{
+			const string Source =
+@"{
+	// Comment A
+	foo |= __FALSE__; // Comment B
+	// Comment C
+	A();
+	// Comment D
+	foo &= __TRUE__; // Comment E
+	// Comment F
+}";
+
+			const string Expected =
+@"{
+	// Comment A
+	// Comment C
+	A();
+	// Comment D
+	// Comment F
+}";
+
+			var actual = ApplyToAllMagicTokens(SyntaxFactory.ParseStatement(Source), true);
+			Assert.That(actual, Is.EqualTo(Expected));
+		}
+
 		#region Implementation
 
 		static string ApplyToAllMagicTokens(SyntaxNode expressionSyntax, bool reformat = false)

--- a/src/WTG.Analyzers.Utils.Test/ExpressionRemoverTest.cs
+++ b/src/WTG.Analyzers.Utils.Test/ExpressionRemoverTest.cs
@@ -38,6 +38,8 @@ namespace WTG.Analyzers.Utils.Test
 		[TestCase("exp |= __FALSE__", ExpectedResult = "exp")]
 		[TestCase("exp &= __TRUE__", ExpectedResult = "exp")]
 		[TestCase("exp &= __FALSE__", ExpectedResult = "exp = false")]
+		[TestCase("(exp &= __TRUE__)", ExpectedResult = "exp")]
+		[TestCase("(exp |= __FALSE__)", ExpectedResult = "exp")]
 		public string ReplaceWithConstantBool_Expression(string expressionText)
 		{
 			return ApplyToAllMagicTokens(SyntaxFactory.ParseExpression(expressionText));
@@ -56,6 +58,10 @@ namespace WTG.Analyzers.Utils.Test
 		[TestCase("while (__TRUE__) A();", ExpectedResult = "while (true) A();")]
 		[TestCase("do A(); while (__FALSE__);", ExpectedResult = "A();")]
 		[TestCase("do A(); while (__TRUE__);", ExpectedResult = "do A(); while (true);")]
+		[TestCase("exp |= __FALSE__;", ExpectedResult = ";")]
+		[TestCase("exp &= __TRUE__;", ExpectedResult = ";")]
+		[TestCase("{ exp |= __FALSE__; }", ExpectedResult = "{ }")]
+		[TestCase("{ exp &= __TRUE__; }", ExpectedResult = "{ }")]
 		public string ReplaceWithConstantBool_Statement(string statementText)
 		{
 			return ApplyToAllMagicTokens(SyntaxFactory.ParseStatement(statementText));

--- a/src/WTG.Analyzers.Utils/ExpressionRemover.cs
+++ b/src/WTG.Analyzers.Utils/ExpressionRemover.cs
@@ -38,7 +38,7 @@ namespace WTG.Analyzers.Utils
 			{
 				var inner = Visit(node.Expression);
 
-				if (CanDiscard(inner))
+				if (CanDiscard(inner) || IsWeak(inner))
 				{
 					return inner.WithTriviaFrom(node);
 				}
@@ -166,6 +166,18 @@ namespace WTG.Analyzers.Utils
 					.WithWhenTrue(whenTrue)
 					.WithWhenFalse(whenFalse)
 					.WithCondition(conditionExpression);
+			}
+
+			public override SyntaxNode? VisitExpressionStatement(ExpressionStatementSyntax node)
+			{
+				var expression = Visit(node.Expression);
+
+				if (IsWeak(expression))
+				{
+					return EmptyStatement.WithTriviaFrom(node);
+				}
+
+				return node.WithExpression((ExpressionSyntax)expression);
 			}
 
 			public override SyntaxNode VisitIfStatement(IfStatementSyntax node)
@@ -364,7 +376,7 @@ namespace WTG.Analyzers.Utils
 					}
 					else
 					{
-						return left.WithTriviaFrom(node);
+						return left.WithTriviaFrom(node).WithAdditionalAnnotations(WeakAnnotation);
 					}
 				}
 


### PR DESCRIPTION
fixes #191

When collapsing an and/or assignment to just the LHS, we mark it as "weak". When visiting an ExpressionStatement, we can detect the weak expression and return the "discardable" empty statement. There is already logic to dissolve the discardable empty statement if it happens to land in a BlockStatement.