### PR TITLE
Fix WTG1002 false-positive in enumerable subclasses

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Result.cs
@@ -69,6 +69,13 @@ public class Bob
 		{
 		}
 	}
+
+	public void ChildImplicitNonGeneric(ChildImplicitNonGenericCollection values)
+	{
+		foreach (int value in values) // can't translate this so don't suggest it
+		{
+		}
+	}
 }
 
 public class MagicCollection<T> : IEnumerable
@@ -107,4 +114,8 @@ public class ImplicitNonGenericCollection : IEnumerable<int>
 {
 	public IEnumerator GetEnumerator() { yield break; }
 	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
+}
+
+public class ChildImplicitNonGenericCollection : ImplicitNonGenericCollection
+{
 }

--- a/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Result.cs
@@ -62,6 +62,13 @@ public class Bob
 		{
 		}
 	}
+
+	public void ImplicitNonGeneric(ImplicitNonGenericCollection values)
+	{
+		foreach (int value in values) // can't translate this so don't suggest it
+		{
+		}
+	}
 }
 
 public class MagicCollection<T> : IEnumerable
@@ -94,4 +101,10 @@ public class AmbigiousCollection : IEnumerable<int>, IEnumerable<double>
 {
 	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
 	IEnumerator<double> IEnumerable<double>.GetEnumerator() { yield break; }
+}
+
+public class ImplicitNonGenericCollection : IEnumerable<int>
+{
+	public IEnumerator GetEnumerator() { yield break; }
+	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
 }

--- a/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Source.cs
@@ -69,6 +69,13 @@ public class Bob
 		{
 		}
 	}
+
+	public void ChildImplicitNonGeneric(ChildImplicitNonGenericCollection values)
+	{
+		foreach (int value in values) // can't translate this so don't suggest it
+		{
+		}
+	}
 }
 
 public class MagicCollection<T> : IEnumerable
@@ -107,4 +114,8 @@ public class ImplicitNonGenericCollection : IEnumerable<int>
 {
 	public IEnumerator GetEnumerator() { yield break; }
 	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
+}
+
+public class ChildImplicitNonGenericCollection : ImplicitNonGenericCollection
+{
 }

--- a/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/VarAnalyzer/Foreach/Source.cs
@@ -62,6 +62,13 @@ public class Bob
 		{
 		}
 	}
+
+	public void ImplicitNonGeneric(ImplicitNonGenericCollection values)
+	{
+		foreach (int value in values) // can't translate this so don't suggest it
+		{
+		}
+	}
 }
 
 public class MagicCollection<T> : IEnumerable
@@ -94,4 +101,10 @@ public class AmbigiousCollection : IEnumerable<int>, IEnumerable<double>
 {
 	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
 	IEnumerator<double> IEnumerable<double>.GetEnumerator() { yield break; }
+}
+
+public class ImplicitNonGenericCollection : IEnumerable<int>
+{
+	public IEnumerator GetEnumerator() { yield break; }
+	IEnumerator<int> IEnumerable<int>.GetEnumerator() { yield break; }
 }

--- a/src/WTG.Analyzers.Utils.Test/EnumerableTypeUtilsTest.cs
+++ b/src/WTG.Analyzers.Utils.Test/EnumerableTypeUtilsTest.cs
@@ -16,6 +16,7 @@ namespace WTG.Analyzers.Utils.Test
 		[TestCase("PreGenericTypedCollection", ExpectedResult = "float")]
 		[TestCase("ExplicitOnlyCollection", ExpectedResult = "double")]
 		[TestCase("ImplicitNonGenericCollection", ExpectedResult = "object")]
+		[TestCase("ChildImplicitNonGenericCollection", ExpectedResult = "object")]
 		public string GetItemType(string enumerableType)
 		{
 			return EnumerableTypeUtils.GetElementType(GetType(enumerableType))?.ToString();
@@ -59,6 +60,10 @@ class ImplicitNonGenericCollection : IEnumerable<double>
 {
 	IEnumerator<double> IEnumerable<double>.GetEnumerator() { yield break; }
 	IEnumerator GetEnumerator() { yield break; }
+}
+
+class ChildImplicitNonGenericCollection : ImplicitNonGenericCollection
+{
 }
 ";
 

--- a/src/WTG.Analyzers.Utils.Test/EnumerableTypeUtilsTest.cs
+++ b/src/WTG.Analyzers.Utils.Test/EnumerableTypeUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,6 +15,7 @@ namespace WTG.Analyzers.Utils.Test
 		[TestCase("IEnumerable", ExpectedResult = "object")]
 		[TestCase("PreGenericTypedCollection", ExpectedResult = "float")]
 		[TestCase("ExplicitOnlyCollection", ExpectedResult = "double")]
+		[TestCase("ImplicitNonGenericCollection", ExpectedResult = "object")]
 		public string GetItemType(string enumerableType)
 		{
 			return EnumerableTypeUtils.GetElementType(GetType(enumerableType))?.ToString();
@@ -52,6 +53,12 @@ class ExplicitOnlyCollection : IEnumerable<double>
 {
 	IEnumerator<double> IEnumerable<double>.GetEnumerator() { yield break; }
 	IEnumerator IEnumerable.GetEnumerator() { yield break; }
+}
+
+class ImplicitNonGenericCollection : IEnumerable<double>
+{
+	IEnumerator<double> IEnumerable<double>.GetEnumerator() { yield break; }
+	IEnumerator GetEnumerator() { yield break; }
 }
 ";
 

--- a/src/WTG.Analyzers.Utils/EnumerableTypeUtils.cs
+++ b/src/WTG.Analyzers.Utils/EnumerableTypeUtils.cs
@@ -22,15 +22,21 @@ namespace WTG.Analyzers.Utils
 
 		static ITypeSymbol? GetExplicitElementType(ITypeSymbol enumerableType)
 		{
-			foreach (var method in enumerableType.GetMembers(nameof(IEnumerable.GetEnumerator)).OfType<IMethodSymbol>())
+			do
 			{
-				if (!method.IsGenericMethod && method.Parameters.Length == 0 && method.TypeArguments.Length == 0)
+				foreach (var method in enumerableType.GetMembers(nameof(IEnumerable.GetEnumerator)).OfType<IMethodSymbol>())
 				{
-					var retType = method.ReturnType;
+					if (!method.IsGenericMethod && method.Parameters.Length == 0 && method.TypeArguments.Length == 0)
+					{
+						var retType = method.ReturnType;
 
-					return GetElementTypeFromEnumeratorType(retType);
+						return GetElementTypeFromEnumeratorType(retType);
+					}
 				}
+
+				enumerableType = enumerableType.BaseType!;
 			}
+			while (enumerableType != null);
 
 			return null;
 		}


### PR DESCRIPTION
This comes from the case discussed in Teams.

When a foreach-able object is invoked via a subclass, we don't necessarily locate the correct `GetEnumerator` method. This PR fixes `EnumerableTypeUtils.GetElementType` to check the base classes as well.

Tracked by WI00633703.