### PR TITLE
Remove old CI workaround

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 6.0.423
 
     - name: Build WTG.Analyzers
       run: dotnet build src --configuration ${{ matrix.configuration }}
@@ -51,7 +51,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 6.0.423
 
     - name: Build NuGet Package
       run: dotnet pack src -p:CommitID=${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,6 @@ jobs:
       with:
         dotnet-version: 6.0.100
 
-    - name: Workaround for https://github.com/dotnet/core/issues/5881
-      run: dotnet nuget locals all --clear
-
     - name: Build WTG.Analyzers
       run: dotnet build src --configuration ${{ matrix.configuration }}
 
@@ -55,9 +52,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.100
-
-    - name: Workaround for https://github.com/dotnet/core/issues/5881
-      run: dotnet nuget locals all --clear
 
     - name: Build NuGet Package
       run: dotnet pack src -p:CommitID=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 6.0.423
         
     - name: Create NuGet Packages
       run: dotnet pack src --configuration Release /p:CommitID=${{ github.sha }} /p:TagVersion=${{ steps.tag_name.outputs.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.100
-
-    - name: Workaround for https://github.com/dotnet/core/issues/5881
-      run: dotnet nuget locals all --clear
         
     - name: Create NuGet Packages
       run: dotnet pack src --configuration Release /p:CommitID=${{ github.sha }} /p:TagVersion=${{ steps.tag_name.outputs.result }}


### PR DESCRIPTION
We shouldn't need this anymore - it was fixed by https://github.com/actions/runner-images/pull/3144 three years ago.