### PR TITLE
Cover WTG1001 on edge cases

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Diagnostics.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics severity="Hidden">
 	<languageVersion>9.0</languageVersion>
-	<suppressId justtification="To ignore when only one method in one class have the code fix removing 'private' applied.">CS8799</suppressId>
+	<suppressId>CS8799</suppressId>
 	<diagnostic id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default.">
 		<location>Test0.cs: (9,3-10)</location>
 	</diagnostic>

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Diagnostics.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <diagnostics severity="Hidden">
 	<languageVersion>9.0</languageVersion>
+	<suppressId justtification="To ignore when only one method in one class have the code fix removing 'private' applied.">CS8799</suppressId>
 	<diagnostic id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default.">
-		<location>Test0.cs: (15,3-10)</location>
+		<location>Test0.cs: (9,3-10)</location>
+	</diagnostic>
+	<diagnostic id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default.">
+		<location>Test0.cs: (19,3-10)</location>
+	</diagnostic>
+	<diagnostic id="WTG1001" message="Our convention is to omit the 'private' modifier where it is already the default.">
+		<location>Test0.cs: (25,3-10)</location>
 	</diagnostic>
 	<diagnostic id="WTG1006" message="Our convention is to omit the 'internal' modifier on types where it is already the default." >
-		<location>Test0.cs: (20,2-10)</location>
+		<location>Test0.cs: (30,2-10)</location>
 	</diagnostic>
 </diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
@@ -3,11 +3,19 @@ namespace ns
 	partial class Foo
 	{
 		private partial int Bar();
+		public partial void FooBar();
+
+		partial void Qux();
+		private partial void Quux(out int value);
 	}
 
 	partial class Foo
 	{
 		private partial int Bar() { return default; }
+		public partial void FooBar() { }
+
+		partial void Qux() { }
+		private partial void Quux(out int value) { value = default; }
 	}
 
 	class Outer

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
@@ -14,7 +14,7 @@ namespace ns
 	{
 		private partial int Bar() { return default; }
 		public partial void FooBar() { }
-		private partial int FooBarBaz(out int value) { value = default; return default; }
+		private partial int FooBarBaz(out int value) => throw null;
 
 		partial void Qux() { }
 		private partial void Quux(out int value) { value = default; }

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Result.cs
@@ -4,6 +4,7 @@ namespace ns
 	{
 		private partial int Bar();
 		public partial void FooBar();
+		private partial int FooBarBaz(out int value);
 
 		partial void Qux();
 		private partial void Quux(out int value);
@@ -13,6 +14,7 @@ namespace ns
 	{
 		private partial int Bar() { return default; }
 		public partial void FooBar() { }
+		private partial int FooBarBaz(out int value) { value = default; return default; }
 
 		partial void Qux() { }
 		private partial void Quux(out int value) { value = default; }

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
@@ -4,6 +4,7 @@ namespace ns
 	{
 		private partial int Bar();
 		public partial void FooBar();
+		private partial int FooBarBaz(out int value);
 
 		private partial void Qux();
 		private partial void Quux(out int value);
@@ -13,6 +14,7 @@ namespace ns
 	{
 		private partial int Bar() { return default; }
 		public partial void FooBar() { }
+		private partial int FooBarBaz(out int value) { value = default; return default; }
 
 		private partial void Qux() { }
 		private partial void Quux(out int value) { value = default; }

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
@@ -14,7 +14,7 @@ namespace ns
 	{
 		private partial int Bar() { return default; }
 		public partial void FooBar() { }
-		private partial int FooBarBaz(out int value) { value = default; return default; }
+		private partial int FooBarBaz(out int value) => throw null;
 
 		private partial void Qux() { }
 		private partial void Quux(out int value) { value = default; }

--- a/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/VisibilityAnalyzer/Partial/Source.cs
@@ -3,11 +3,19 @@ namespace ns
 	partial class Foo
 	{
 		private partial int Bar();
+		public partial void FooBar();
+
+		private partial void Qux();
+		private partial void Quux(out int value);
 	}
 
 	partial class Foo
 	{
 		private partial int Bar() { return default; }
+		public partial void FooBar() { }
+
+		private partial void Qux() { }
+		private partial void Quux(out int value) { value = default; }
 	}
 
 	class Outer

--- a/src/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/Visibility/VisibilityAnalyzer.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using WTG.Analyzers.Utils;
 
@@ -32,7 +34,8 @@ namespace WTG.Analyzers
 				return;
 			}
 
-			var list = ModifierExtractionVisitor.Instance.Visit(context.Node);
+			var currentNode = context.Node;
+			var list = ModifierExtractionVisitor.Instance.Visit(currentNode);
 			var privateToken = default(SyntaxToken);
 
 			foreach (var modifier in list)
@@ -47,11 +50,10 @@ namespace WTG.Analyzers
 
 					case SyntaxKind.ProtectedKeyword:
 					case SyntaxKind.PublicKeyword:
-					case SyntaxKind.PartialKeyword when (context.Node.IsKind(SyntaxKind.MethodDeclaration)):
+					case SyntaxKind.PartialKeyword when (DoesMethodHaveReturnValueOrOutKeyword(currentNode)):
 						return;
-
 					case SyntaxKind.InternalKeyword:
-						if (IsTopLevel(context.Node))
+						if (IsTopLevel(currentNode))
 						{
 							context.ReportDiagnostic(Rules.CreateDoNotUseTheInternalKeywordForTopLevelTypesDiagnostic(modifier.GetLocation()));
 						}
@@ -63,6 +65,28 @@ namespace WTG.Analyzers
 			{
 				context.ReportDiagnostic(Rules.CreateDoNotUseThePrivateKeywordDiagnostic(privateToken.GetLocation()));
 			}
+		}
+
+		static bool DoesMethodHaveReturnValueOrOutKeyword(SyntaxNode node)
+		{
+			if (!node.IsKind(SyntaxKind.MethodDeclaration))
+			{
+				return false;
+			}
+
+			var methodNode = (MethodDeclarationSyntax)node;
+			if (methodNode.ReturnType is PredefinedTypeSyntax predefinedTypeSyntax
+				&& !predefinedTypeSyntax.Keyword.IsKind(SyntaxKind.VoidKeyword))
+			{
+				return true;
+			}
+
+			if (methodNode.ParameterList?.Parameters.Any(c => c.Modifiers.Any(SyntaxKind.OutKeyword)) == true)
+			{
+				return true;
+			}
+
+			return false;
 		}
 
 		static bool IsTopLevel(SyntaxNode node)


### PR DESCRIPTION
Fix #224 
Tracked by [WI00764889](https://svc-ediprod.wtg.zone/Services/link/ShowEditForm/WorkItem/75870954-7a36-4dc4-9e37-806a85aa3bb2?lang=en-gb)

- A method with default access modifier, partial, return value
e.g. private partial int Bar(); // no error as it returns value

- A partial method with non-default access modifier, void
e.g. public partial void Bar(); // no error as it returns value

- A partial method with default access modifier, void
e.g. private partial void Bar(); // trigger WTG1001 and remove 'private' when code-fix run

- A partial method with default access modifier, void, out value
e.g. private partial void Bar(out int value); // no error as it 'out' a value

- A partial method with default access modifier, return value, out value
e.g. private partial int Bar(out int value); // no error as it returns and 'out' a value
