### PR TITLE
Conditionalise loading of NetAnalyzers

### DIFF
--- a/src/WTG.Analyzers/WTG.Analyzers.csproj
+++ b/src/WTG.Analyzers/WTG.Analyzers.csproj
@@ -8,11 +8,16 @@
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+  <ItemGroup Condition="'$(TargetFramework)' != ''">
+    <!-- Disable for SDK 9 and above -->
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers"
+                      Version="8.0.0"
+                      Condition="!$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0.100'))" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Only load V8 rules for lower than 9 SDK (as this SDK already loads it by default, causing duplicate loads)