### PR TITLE
GHA: Remove explicit SDK version so that global.json governs it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.300
 
     - name: Build WTG.Analyzers
       run: dotnet build src --configuration ${{ matrix.configuration }}
@@ -50,8 +48,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.300
 
     - name: Build NuGet Package
       run: dotnet pack src -p:CommitID=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,6 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.300
 
     - name: Create NuGet Packages
       run: dotnet pack src --configuration Release /p:CommitID=${{ github.sha }} /p:TagVersion=${{ steps.tag_name.outputs.result }}


### PR DESCRIPTION
This PR removes `with.dotnet-version` from `actions/setup-dotnet` calls, which will let it default back to reading from `global.json` and installing the most appropriate SDK based on that.