### PR TITLE
WTG1007: Ignore C# 9.0 lambda discards

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodDiscard/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodDiscard/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>9</languageVersion>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodDiscard/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodDiscard/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N(delegate(int _, int _) { });
+	}
+
+	protected abstract void N(Action<int, int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodSingleUnderscore/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodSingleUnderscore/Diagnostics.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG1017" message="This variable could be confused with a discard." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,18-19)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodSingleUnderscore/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/AnonymousMethodSingleUnderscore/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N(delegate(int _) { });
+	}
+
+	protected abstract void N(Action<int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPair/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPair/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>9</languageVersion>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPair/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPair/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N((_, _) => 0);
+	}
+
+	protected abstract void N(Func<int, int, int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPairExplicitlyTyped/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPairExplicitlyTyped/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>9</languageVersion>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPairExplicitlyTyped/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardPairExplicitlyTyped/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N((int _, int _) => 0);
+	}
+
+	protected abstract void N(Func<int, int, int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardTriple/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardTriple/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>9</languageVersion>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardTriple/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaDiscardTriple/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N((_, _, _) => 0);
+	}
+
+	protected abstract void N(Func<int, int, int, int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaMixedSingleUnderscore/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaMixedSingleUnderscore/Diagnostics.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG1017" message="This variable could be confused with a discard." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (7,6-7)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaMixedSingleUnderscore/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/LambdaMixedSingleUnderscore/Source.cs
@@ -1,0 +1,11 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N((_, x) => { });
+	}
+
+	protected abstract void N(Action<int, int> x);
+}

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/NestedLambdaDiscards/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/NestedLambdaDiscards/Diagnostics.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics>
+	<languageVersion>9</languageVersion>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/NestedLambdaDiscards/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/DiscardVariableAnalyzer/NestedLambdaDiscards/Source.cs
@@ -1,0 +1,12 @@
+using System;
+
+public abstract class Bob
+{
+	public void M()
+	{
+		N((_, _) => O((_, _) => 0));
+	}
+
+	protected abstract int N(Func<int, int, int> x);
+	protected abstract int O(Func<int, int, int> x);
+}

--- a/src/WTG.Analyzers/Analyzers/DiscardVariable/DiscardVariableAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/DiscardVariable/DiscardVariableAnalyzer.cs
@@ -87,10 +87,33 @@ namespace WTG.Analyzers
 		{
 			var identifier = node.Identifier;
 
-			if (identifier.Text == "_")
+			if (identifier.Text == "_" && !IsLambdaDiscard(node))
 			{
 				context.ReportDiagnostic(Rules.CreateVariableCouldBeConfusedWithDiscardDiagnostic(identifier.GetLocation()));
 			}
+		}
+
+		static bool IsLambdaDiscard(ParameterSyntax node)
+		{
+			// From C# 9, when a lambda or anonymous method has two or more parameters
+			// named '_', they are all genuine discards rather than confusable variables.
+			// A single '_' parameter remains a real parameter for backwards compatibility.
+			if (node.Parent is ParameterListSyntax list &&
+				(list.Parent.IsKind(SyntaxKind.ParenthesizedLambdaExpression) ||
+				list.Parent.IsKind(SyntaxKind.AnonymousMethodExpression)))
+			{
+				var count = 0;
+
+				foreach (var parameter in list.Parameters)
+				{
+					if (parameter.Identifier.Text == "_" && ++count > 1)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
 		}
 
 		static void Analyze(SyntaxNodeAnalysisContext context, VariableDeclaratorSyntax node)


### PR DESCRIPTION
Starting with C# 9.0, if a lambda/delegate has multiple parameters named '_' they are all discards.
A single parameter named '_' is still treated as a variable for backwards compatibility.

This PR removes false-positives in WTG1007 from warning that lambda discards (which are discards) could
be confused with discards.

Fixes #159.
