### PR TITLE
Address WTG3012 code-fix review feedback

### DIFF
--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Diagnostics.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3012" message="Boolean expression can be simplified." severity="Info">
+	<diagnostic>
+		<location>Test0.cs: (4,44-49)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Result.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Result.cs
@@ -1,0 +1,6 @@
+public static class Bob
+{
+#if true
+	public static bool Method(bool a) => a;
+#endif
+}

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/DirectivesAroundMember/Source.cs
@@ -1,0 +1,6 @@
+public static class Bob
+{
+#if true
+	public static bool Method(bool a) => a || false;
+#endif
+}

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/WithPreprocessorDirectives/Diagnostics.xml
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/WithPreprocessorDirectives/Diagnostics.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<diagnostics id="WTG3012" message="Boolean expression can be simplified." severity="Info">
+	<allowCodeFixes>false</allowCodeFixes>
+	<diagnostic>
+		<location>Test0.cs: (9,4-8)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (14,10-15)</location>
+	</diagnostic>
+	<diagnostic>
+		<location>Test0.cs: (25,54-58)</location>
+	</diagnostic>
+</diagnostics>

--- a/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/WithPreprocessorDirectives/Source.cs
+++ b/src/WTG.Analyzers.Test/TestData/BooleanLiteralCombiningAnalyzer/WithPreprocessorDirectives/Source.cs
@@ -1,0 +1,30 @@
+public static class Bob
+{
+	public static bool Conditional(bool? something)
+	{
+		return
+#if true
+			something.HasValue ? something.Value :
+#endif
+			true;
+	}
+
+	public static bool Or(bool value0, bool value1, bool value2)
+	{
+		return false
+#if true
+			|| (
+				value0 &&
+				value1 &&
+				value2
+			)
+#endif
+			;
+	}
+
+	public static bool And(bool value0, bool value1) => true
+#if true
+		&& !(value0 && value1)
+#endif
+		;
+}

--- a/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningAnalyzer.cs
+++ b/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningAnalyzer.cs
@@ -39,7 +39,8 @@ namespace WTG.Analyzers
 
 			if (CanBeSimplified(context.Node, context.SemanticModel, context.CancellationToken))
 			{
-				if (IsValueCoercion(context.Node))
+				// Skip the code-fix when #if splits the expression; rewriting would drop the directives (CS1027).
+				if (IsValueCoercion(context.Node) || SurroundingExpressionContainsDirectives(context.Node))
 				{
 					context.ReportDiagnostic(
 						Diagnostic.Create(
@@ -138,6 +139,36 @@ namespace WTG.Analyzers
 
 			value = false;
 			return false;
+		}
+
+		static bool SurroundingExpressionContainsDirectives(SyntaxNode node)
+		{
+			var current = node;
+
+			while (current.Parent != null && IsBooleanCombiningExpression(current.Parent))
+			{
+				current = current.Parent;
+			}
+
+			return current.ContainsDirectives;
+		}
+
+		static bool IsBooleanCombiningExpression(SyntaxNode node)
+		{
+			switch (node.Kind())
+			{
+				case SyntaxKind.LogicalAndExpression:
+				case SyntaxKind.LogicalOrExpression:
+				case SyntaxKind.LogicalNotExpression:
+				case SyntaxKind.ParenthesizedExpression:
+				case SyntaxKind.AndAssignmentExpression:
+				case SyntaxKind.OrAssignmentExpression:
+				case SyntaxKind.ConditionalExpression:
+					return true;
+
+				default:
+					return false;
+			}
 		}
 	}
 }

--- a/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningFixAllProvider.cs
+++ b/src/WTG.Analyzers/Analyzers/BooleanLiteralCombining/BooleanLiteralCombiningFixAllProvider.cs
@@ -19,6 +19,11 @@ namespace WTG.Analyzers
 
 			foreach (var diagnostic in diagnostics)
 			{
+				if (!CommonDiagnosticProperties.CanAutoFix(diagnostic))
+				{
+					continue;
+				}
+
 				var expression = (LiteralExpressionSyntax)root.FindNode(
 					diagnostic.Location.SourceSpan,
 					getInnermostNodeForTie: true);


### PR DESCRIPTION
Share the governing syntax node between simplification and directive checks.
Clarify the preprocessor-directive safety comment.
Ensure Fix All respects CanAutoFix.
Add regressions for directive trivia and IsValueCoercion.
Verify all tests on net8.0 and net472.